### PR TITLE
fix: headers and actions empty variable init

### DIFF
--- a/__tests__/fileAction.spec.ts
+++ b/__tests__/fileAction.spec.ts
@@ -1,5 +1,6 @@
-/* eslint-disable no-new */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable no-new */
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { getFileActions, registerFileAction, FileAction } from '../lib/fileAction'
@@ -38,6 +39,27 @@ describe('FileActions init', () => {
 		expect(getFileActions()).toHaveLength(1)
 		expect(getFileActions()[0]).toStrictEqual(action)
 		expect(logger.debug).toHaveBeenCalled()
+	})
+
+	test('getFileActions() returned array is reactive', () => {
+		logger.debug = vi.fn()
+
+		const actions = getFileActions()
+		// is empty for now
+		expect(actions).toHaveLength(0)
+
+		const action = new FileAction({
+			id: 'test',
+			displayName: () => 'Test',
+			iconSvgInline: () => '<svg></svg>',
+			exec: async () => true,
+		})
+
+		registerFileAction(action)
+
+		// Now the array changed as it should be reactive
+		expect(actions).toHaveLength(1)
+		expect(actions[0]).toStrictEqual(action)
 	})
 
 	test('Duplicate FileAction gets rejected', () => {

--- a/__tests__/fileAction.spec.ts
+++ b/__tests__/fileAction.spec.ts
@@ -14,9 +14,9 @@ describe('FileActions init', () => {
 	test('Getting empty uninitialized FileActions', () => {
 		logger.debug = vi.fn()
 		const fileActions = getFileActions()
-		expect(window._nc_fileactions).toBeUndefined()
+		expect(window._nc_fileactions).toBeDefined()
 		expect(fileActions).toHaveLength(0)
-		expect(logger.debug).toHaveBeenCalledTimes(0)
+		expect(logger.debug).toHaveBeenCalledTimes(1)
 	})
 
 	test('Initializing FileActions', () => {

--- a/__tests__/fileListHeaders.spec.ts
+++ b/__tests__/fileListHeaders.spec.ts
@@ -12,9 +12,9 @@ describe('FileListHeader init', () => {
 	test('Getting empty uninitialized FileListHeader', () => {
 		logger.debug = vi.fn()
 		const headers = getFileListHeaders()
-		expect(window._nc_filelistheader).toBeUndefined()
+		expect(window._nc_filelistheader).toBeDefined()
 		expect(headers).toHaveLength(0)
-		expect(logger.debug).toHaveBeenCalledTimes(0)
+		expect(logger.debug).toHaveBeenCalledTimes(1)
 	})
 
 	test('Initializing FileListHeader', () => {

--- a/__tests__/fileListHeaders.spec.ts
+++ b/__tests__/fileListHeaders.spec.ts
@@ -1,10 +1,11 @@
-/* eslint-disable no-new */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable no-new */
 import { describe, expect, test, beforeEach, vi } from 'vitest'
 
+import { Folder } from '../lib/files/folder'
 import { Header, getFileListHeaders, registerFileListHeaders } from '../lib/fileListHeaders'
 import logger from '../lib/utils/logger'
-import { Folder } from '../lib/files/folder'
 
 describe('FileListHeader init', () => {
 
@@ -40,6 +41,28 @@ describe('FileListHeader init', () => {
 		expect(getFileListHeaders()).toHaveLength(1)
 		expect(getFileListHeaders()[0]).toStrictEqual(header)
 		expect(logger.debug).toHaveBeenCalled()
+	})
+
+	test('getFileListHeaders() returned array is reactive', () => {
+		logger.debug = vi.fn()
+
+		const headers = getFileListHeaders()
+		// is empty for now
+		expect(headers).toHaveLength(0)
+
+		const header = new Header({
+			id: 'test',
+			order: 1,
+			enabled: () => true,
+			render: () => {},
+			updated: () => {},
+		})
+
+		registerFileListHeaders(header)
+
+		// Now the array changed as it should be reactive
+		expect(headers).toHaveLength(1)
+		expect(headers[0]).toStrictEqual(header)
 	})
 
 	test('Duplicate Header gets rejected', () => {

--- a/__tests__/fileListHeaders.spec.ts
+++ b/__tests__/fileListHeaders.spec.ts
@@ -1,4 +1,7 @@
+/* eslint-disable no-new */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, expect, test, beforeEach, vi } from 'vitest'
+
 import { Header, getFileListHeaders, registerFileListHeaders } from '../lib/fileListHeaders'
 import logger from '../lib/utils/logger'
 import { Folder } from '../lib/files/folder'
@@ -63,5 +66,101 @@ describe('FileListHeader init', () => {
 		expect(getFileListHeaders()).toHaveLength(1)
 		expect(getFileListHeaders()[0]).toStrictEqual(header)
 		expect(logger.error).toHaveBeenCalledWith('Header test already registered', { header: header2 })
+	})
+})
+
+describe('FileListHeader validate', () => {
+	test('Missing required props', () => {
+		expect(() => {
+			new Header({
+				id: null,
+				render: () => {},
+				updated: () => {},
+			} as any as Header)
+		}).toThrowError('Invalid header: id, render and updated are required')
+
+		expect(() => {
+			new Header({
+				id: '123',
+				render: null,
+				updated: () => {},
+			} as any as Header)
+		}).toThrowError('Invalid header: id, render and updated are required')
+
+		expect(() => {
+			new Header({
+				id: '123',
+				render: () => {},
+				updated: null,
+			} as any as Header)
+		}).toThrowError('Invalid header: id, render and updated are required')
+	})
+	test('Invalid id', () => {
+		expect(() => {
+			new Header({
+				id: true,
+				render: () => {},
+				updated: () => {},
+			} as any as Header)
+		}).toThrowError('Invalid id property')
+	})
+	test('Invalid enabled', () => {
+		expect(() => {
+			new Header({
+				id: 'test',
+				enabled: true,
+				render: () => {},
+				updated: () => {},
+			} as any as Header)
+		}).toThrowError('Invalid enabled property')
+	})
+	test('Invalid render', () => {
+		expect(() => {
+			new Header({
+				id: 'test',
+				enabled: () => {},
+				render: true,
+				updated: () => {},
+			} as any as Header)
+		}).toThrowError('Invalid render property')
+	})
+	test('Invalid updated', () => {
+		expect(() => {
+			new Header({
+				id: 'test',
+				enabled: () => {},
+				render: () => {},
+				updated: true,
+			} as any as Header)
+		}).toThrowError('Invalid updated property')
+	})
+})
+
+describe('FileListHeader exec', () => {
+
+	test('Initializing FileListHeader', () => {
+		const enabled = vi.fn()
+		const render = vi.fn()
+		const updated = vi.fn()
+
+		const header = new Header({
+			id: 'test',
+			order: 1,
+			enabled,
+			render,
+			updated,
+		})
+
+		expect(header.enabled).toBe(enabled)
+		expect(header.render).toBe(render)
+		expect(header.updated).toBe(updated)
+
+		header.enabled!({} as Folder, {})
+		header.render(null as any as HTMLElement, {} as Folder, {})
+		header.updated({} as Folder, {})
+
+		expect(enabled).toHaveBeenCalled()
+		expect(render).toHaveBeenCalled()
+		expect(updated).toHaveBeenCalled()
 	})
 })

--- a/lib/fileAction.ts
+++ b/lib/fileAction.ts
@@ -171,5 +171,10 @@ export const registerFileAction = function(action: FileAction): void {
 }
 
 export const getFileActions = function(): FileAction[] {
-	return window._nc_fileactions || []
+	if (typeof window._nc_fileactions === 'undefined') {
+		window._nc_fileactions = []
+		logger.debug('FileActions initialized')
+	}
+
+	return window._nc_fileactions
 }

--- a/lib/fileListHeaders.ts
+++ b/lib/fileListHeaders.ts
@@ -92,7 +92,7 @@ export class Header {
 export const registerFileListHeaders = function(header: Header): void {
 	if (typeof window._nc_filelistheader === 'undefined') {
 		window._nc_filelistheader = []
-		logger.debug('FileActions initialized')
+		logger.debug('FileListHeaders initialized')
 	}
 
 	// Check duplicates
@@ -105,5 +105,10 @@ export const registerFileListHeaders = function(header: Header): void {
 }
 
 export const getFileListHeaders = function(): Header[] {
-	return window._nc_filelistheader || []
+	if (typeof window._nc_filelistheader === 'undefined') {
+		window._nc_filelistheader = []
+		logger.debug('FileListHeaders initialized')
+	}
+
+	return window._nc_filelistheader
 }


### PR DESCRIPTION
Otherwise if an app uses `getFileActions` or  `getFileListHeaders` BEFORE any other app registered one, the returned empty array will not point to the window reference and will not be reactive