### PR TITLE
fix: getNewFileMenuEntries usage

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -22,7 +22,8 @@
  */
 
 import { type Entry, getNewFileMenu } from './newFileMenu'
-import { Folder } from './files/folder'
+import { type Folder } from './files/folder'
+import { type View } from './navigation/view'
 
 export { formatFileSize } from './humanfilesize'
 export { FileAction, getFileActions, registerFileAction, DefaultType } from './fileAction'
@@ -67,8 +68,9 @@ export const removeNewFileMenuEntry = function(entry: Entry | string) {
  * Get the list of registered entries from the upload menu
  *
  * @param {Folder} context the creation context. Usually the current folder FileInfo
+ * @param {View} view the current view
  */
-export const getNewFileMenuEntries = function(context?: Folder) {
+export const getNewFileMenuEntries = function(context?: Folder, view?: View) {
 	const newFileMenu = getNewFileMenu()
-	return newFileMenu.getEntries(context)
+	return newFileMenu.getEntries(context, view)
 }

--- a/lib/navigation/view.ts
+++ b/lib/navigation/view.ts
@@ -126,12 +126,24 @@ export class View implements ViewData {
 		return this._view.icon
 	}
 
+	set icon(icon) {
+		this._view.icon = icon
+	}
+
 	get order() {
 		return this._view.order
 	}
 
+	set order(order) {
+		this._view.order = order
+	}
+
 	get params() {
 		return this._view.params
+	}
+
+	set params(params) {
+		this._view.params = params
 	}
 
 	get columns() {
@@ -152,6 +164,10 @@ export class View implements ViewData {
 
 	get expanded() {
 		return this._view.expanded
+	}
+
+	set expanded(expanded: boolean | undefined) {
+		this._view.expanded = expanded
 	}
 
 	get defaultSortKey() {


### PR DESCRIPTION
@susnux  I have an issue with this when testing https://github.com/nextcloud/server/pull/39955

```
    TypeError: T is not a function

      40 | export default () => {
      41 | 	const Navigation = getNavigation()
    > 42 | 	Navigation.register(new View({
         | 	                    ^
      43 | 		id: sharesViewId,
      44 | 		name: t('files_sharing', 'Shares'),
      45 | 		caption: t('files_sharing', 'Overview of shared files.'),

      at isSvg (node_modules/@nextcloud/files/lib/navigation/view.ts:205:54)
      at new isValidView (node_modules/@nextcloud/files/lib/navigation/view.ts:97:3)
      at Object.<anonymous>.exports.default (apps/files_sharing/src/views/shares.ts:42:22)
      at Object.<anonymous> (apps/files_sharing/src/views/shares.spec.ts:122:23)
```

If I bundle `is-svg` into the vite config, it works, but otherwise it fails.
Any clue? This only happens when running jest on server with https://github.com/nextcloud/server/pull/39955 (you'll have to build this PR and use this code of course)