### PR TITLE
feat(files): add node status

### DIFF
--- a/__tests__/files/file.spec.ts
+++ b/__tests__/files/file.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest'
 import { File } from '../../lib/files/file'
 import { FileType } from '../../lib/files/fileType'
 import { Permission } from '../../lib/permissions'
+import { NodeStatus } from '../../lib/files/node'
 
 describe('File creation', () => {
 	test('Valid dav file', () => {
@@ -12,6 +13,7 @@ describe('File creation', () => {
 			owner: 'emma',
 			mtime: new Date(Date.UTC(2023, 0, 1, 0, 0, 0)),
 			crtime: new Date(Date.UTC(1990, 0, 1, 0, 0, 0)),
+			status: NodeStatus.NEW,
 		})
 
 		expect(file).toBeInstanceOf(File)
@@ -35,6 +37,7 @@ describe('File creation', () => {
 		expect(file.path).toBe('/picture.jpg')
 		expect(file.isDavRessource).toBe(true)
 		expect(file.permissions).toBe(Permission.NONE)
+		expect(file.status).toBe(NodeStatus.NEW)
 	})
 
 	test('Valid dav file with root', () => {
@@ -169,6 +172,19 @@ describe('File data change', () => {
 		expect(file.dirname).toBe('/Pictures/Old')
 		expect(file.source).toBe('https://cloud.domain.com/remote.php/dav/files/emma/Pictures/Old/picture-old.jpg')
 		expect(file.root).toBe('/files/emma')
+	})
+
+	test('Changing status', () => {
+		const file = new File({
+			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			mime: 'image/jpeg',
+			owner: 'emma',
+			root: '/files/emma',
+		})
+
+		expect(file.status).toBeUndefined()
+		file.status = NodeStatus.NEW
+		expect(file.status).toBe(NodeStatus.NEW)
 	})
 })
 

--- a/__tests__/files/node.spec.ts
+++ b/__tests__/files/node.spec.ts
@@ -4,6 +4,7 @@ import { File } from '../../lib/files/file'
 import { Folder } from '../../lib/files/folder'
 import { Attribute, NodeData } from '../../lib/files/nodeData'
 import { Permission } from '../../lib/permissions'
+import { NodeStatus } from '../../lib/files/node'
 
 describe('Node testing', () => {
 	test('Root null fallback', () => {
@@ -194,6 +195,15 @@ describe('Sanity checks', () => {
 			owner: 'emma',
 			root: '/remote.php/dav/files/emma',
 		})).toThrowError('The root must be relative to the service. e.g /files/emma')
+	})
+
+	test('Invalid status', () => {
+		expect(() => new File({
+			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			mime: 'image/jpeg',
+			owner: 'emma',
+			status: 'invalid' as unknown as NodeStatus,
+		})).toThrowError('Status must be a valid NodeStatus')
 	})
 })
 

--- a/lib/files/node.ts
+++ b/lib/files/node.ts
@@ -24,6 +24,17 @@ import { Permission } from '../permissions'
 import { FileType } from './fileType'
 import { Attribute, NodeData, isDavRessource, validateData } from './nodeData'
 
+export enum NodeStatus {
+	/** This is a new node and it doesn't exists on the filesystem yet */
+	NEW = 'new',
+	/** This node has failed and is unavailable  */
+	FAILED = 'failed',
+	/** This node is currently loading or have an operation in progress */
+	LOADING = 'loading',
+	/** This node is locked and cannot be modified */
+	LOCKED = 'locked',
+}
+
 export abstract class Node {
 
 	private _data: NodeData
@@ -211,6 +222,20 @@ export abstract class Node {
 	 */
 	get fileid(): number|undefined {
 		return this._data?.id || this.attributes?.fileid
+	}
+
+	/**
+	 * Get the node status.
+	 */
+	get status(): NodeStatus|undefined {
+		return this._data?.status
+	}
+
+	/**
+	 * Set the node status.
+	 */
+	set status(status: NodeStatus|undefined) {
+		this._data.status = status
 	}
 
 	/**

--- a/lib/files/nodeData.ts
+++ b/lib/files/nodeData.ts
@@ -22,6 +22,7 @@
 
 import { join } from 'path'
 import { Permission } from '../permissions'
+import { NodeStatus } from './node'
 
 export interface Attribute { [key: string]: any }
 
@@ -54,6 +55,7 @@ export interface NodeData {
 	/** The owner  UID of this node */
 	owner: string|null
 
+	/** The node attributes */
 	attributes?: Attribute
 
 	/**
@@ -62,6 +64,9 @@ export interface NodeData {
 	 * e.g. /files/emma
 	 */
 	root?: string
+
+	/** The node status */
+	status?: NodeStatus
 }
 
 /**
@@ -155,5 +160,9 @@ export const validateData = (data: NodeData, davService: RegExp) => {
 		if (!data.source.includes(join(service, data.root))) {
 			throw new Error('The root must be relative to the service. e.g /files/emma')
 		}
+	}
+
+	if (data.status && !Object.values(NodeStatus).includes(data.status)) {
+		throw new Error('Status must be a valid NodeStatus')
 	}
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,7 +23,6 @@
 
 import { type Entry, getNewFileMenu } from './newFileMenu'
 import { type Folder } from './files/folder'
-import { type View } from './navigation/view'
 
 export { formatFileSize } from './humanfilesize'
 export { FileAction, getFileActions, registerFileAction, DefaultType } from './fileAction'
@@ -38,7 +37,7 @@ export * from './dav/dav'
 export { FileType } from './files/fileType'
 export { File } from './files/file'
 export { Folder } from './files/folder'
-export { Node } from './files/node'
+export { Node, NodeStatus } from './files/node'
 
 export * from './navigation/navigation'
 export * from './navigation/column'


### PR DESCRIPTION
```ts
/** This is a new node and it doesn't exists on the filesystem yet */
NEW = 'new',
/** This node has failed and is unavailable  */
FAILED = 'failed',
/** This node is currently loading or have an operation in progress */
LOADING = 'loading',
/** This node is locked and cannot be modified */
LOCKED = 'locked',
```

Makes it a bit more official instead of those weird hidden values
e.g https://github.com/nextcloud/server/blob/4e60b3c61e8e0699e341fb62f9f109d2525be5ab/apps/files/src/services/Files.ts#L65