### PR TITLE
fix(formatFileSize): Fix default value for `binaryPrefixes`

### DIFF
--- a/__tests__/humanFileSize.spec.ts
+++ b/__tests__/humanFileSize.spec.ts
@@ -4,6 +4,10 @@ import { formatFileSize } from '../lib/humanfilesize'
 
 describe('humanFileSize', () => {
 	describe('formatFileSize', () => {
+		it('renders binary sizes by default', () => {
+			expect(formatFileSize(2048)).toBe('2 KiB')
+		})
+
 		it('renders file sizes with the correct unit', function() {
 			const dataDecimal = [
 				[0, '0 B'],
@@ -30,7 +34,7 @@ describe('humanFileSize', () => {
 				[128000000000000000.0, '113.7 PiB'],
 			]
 			for (let i = 0; i < dataDecimal.length; i++) {
-				expect(formatFileSize(dataDecimal[i][0])).toEqual(dataDecimal[i][1])
+				expect(formatFileSize(dataDecimal[i][0], false, false)).toEqual(dataDecimal[i][1])
 			}
 			for (let i = 0; i < dataBinary.length; i++) {
 				expect(formatFileSize(dataBinary[i][0], false, true)).toEqual(dataBinary[i][1])
@@ -59,7 +63,7 @@ describe('humanFileSize', () => {
 				[128000000000000000.0, '113.7 PiB'],
 			]
 			for (let i = 0; i < dataDecimal.length; i++) {
-				expect(formatFileSize(dataDecimal[i][0], true)).toEqual(dataDecimal[i][1])
+				expect(formatFileSize(dataDecimal[i][0], true, false)).toEqual(dataDecimal[i][1])
 			}
 			for (let i = 0; i < dataBinary.length; i++) {
 				expect(formatFileSize(dataBinary[i][0], true, true)).toEqual(dataBinary[i][1])
@@ -93,7 +97,7 @@ describe('humanFileSize', () => {
 				[128000000000000000.0, '113,7 PiB'],
 			]
 			for (let i = 0; i < dataDecimal.length; i++) {
-				expect(formatFileSize(dataDecimal[i][0])).toEqual(dataDecimal[i][1])
+				expect(formatFileSize(dataDecimal[i][0], false, false)).toEqual(dataDecimal[i][1])
 			}
 			for (let i = 0; i < dataBinary.length; i++) {
 				expect(formatFileSize(dataBinary[i][0], false, true)).toEqual(dataBinary[i][1])

--- a/lib/humanfilesize.ts
+++ b/lib/humanfilesize.ts
@@ -31,9 +31,9 @@ const humanListBinary = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB']
  *
  * @param size in bytes
  * @param skipSmallSizes avoid rendering tiny sizes and return '< 1 KB' instead
- * @param binaryPrefixes True if binary prefixes like `KiB` should be used (size base 2)
+ * @param binaryPrefixes True if size base 2 (and binary prefixes like `KiB`) should be used
  */
-export function formatFileSize(size: number|string, skipSmallSizes = false, binaryPrefixes = false): string {
+export function formatFileSize(size: number|string, skipSmallSizes = false, binaryPrefixes = true): string {
 
 	if (typeof size === 'string') {
 		size = Number(size)


### PR DESCRIPTION
The default was previously on Nextcloud core set to true, so bytes were formatted using base 2. (But the wrong unit was used, e.g. 1024 byte were formatted as 1 KB). This reverts the default to format sizes using the binary format (1024 = 1 KiB).