### PR TITLE
feat: support new file menu entry order

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -70,5 +70,10 @@ export const removeNewFileMenuEntry = function(entry: Entry | string) {
  */
 export const getNewFileMenuEntries = function(context?: Folder) {
 	const newFileMenu = getNewFileMenu()
-	return newFileMenu.getEntries(context)
+	return newFileMenu.getEntries(context).sort((a: Entry, b: Entry) => {
+		if (a.order !== undefined && b.order !== undefined) {
+			return a.order - b.order
+		}
+		return a.displayName.localeCompare(b.displayName)
+	})
 }


### PR DESCRIPTION
- `templateName` is not used as the file creation is now handled by the developers themselves
- Renamed `if` to `enabled` to match other APIs
- To ensure we can have a custom order, I also added an order key

| Before | After with custom order |
|:---------:|:------:|
|![image](https://github.com/nextcloud-libraries/nextcloud-files/assets/14975046/4bd4af25-13e2-4b07-8f4b-924360784b2f)|![image](https://github.com/nextcloud-libraries/nextcloud-files/assets/14975046/75cfb7cb-03a6-44aa-8555-f8b417464b0f)|
