### PR TITLE
feat!: add NodeData.encodedSource 

### DIFF
--- a/__tests__/dav/dav.spec.ts
+++ b/__tests__/dav/dav.spec.ts
@@ -50,6 +50,7 @@ describe('davResultToNode', () => {
 		expect(node.basename).toBe(result.basename)
 		expect(node.extension).toBe('.md')
 		expect(node.source).toBe('https://localhost/dav/files/test/New folder/Neue Textdatei.md')
+		expect(node.encodedSource).toBe('https://localhost/dav/files/test/New%20folder/Neue%20Textdatei.md')
 		expect(node.root).toBe(davRootPath)
 		expect(node.path).toBe('/New folder/Neue Textdatei.md')
 		expect(node.dirname).toBe('/New folder')
@@ -65,6 +66,7 @@ describe('davResultToNode', () => {
 		expect(node.extension).toBe('.md')
 		expect(node.root).toBe('/root')
 		expect(node.source).toBe('https://localhost/dav/root/New folder/Neue Textdatei.md')
+		expect(node.encodedSource).toBe('https://localhost/dav/root/New%20folder/Neue%20Textdatei.md')
 		expect(node.path).toBe('/New folder/Neue Textdatei.md')
 		expect(node.dirname).toBe('/New folder')
 	})
@@ -75,8 +77,20 @@ describe('davResultToNode', () => {
 		expect(node.basename).toBe(remoteResult.basename)
 		expect(node.extension).toBe('.md')
 		expect(node.source).toBe('http://example.com/dav/root/New folder/Neue Textdatei.md')
+		expect(node.encodedSource).toBe('http://example.com/dav/root/New%20folder/Neue%20Textdatei.md')
 		expect(node.path).toBe('/New folder/Neue Textdatei.md')
 		expect(node.dirname).toBe('/New folder')
+	})
+
+	test('encode special characters', () => {
+		const remoteResult = { ...result, basename: 'realy #1\'s.md', filename: '/root/~⛰️ shot of a $[big} mountain/realy #1\'s.md' }
+		const node = davResultToNode(remoteResult, '/root', 'http://example.com/dav')
+		expect(node.basename).toBe(remoteResult.basename)
+		expect(node.extension).toBe('.md')
+		expect(node.source).toBe('http://example.com/dav/root/~⛰️ shot of a $[big} mountain/realy #1\'s.md')
+		expect(node.encodedSource).toBe('http://example.com/dav/root/~%E2%9B%B0%EF%B8%8F%20shot%20of%20a%20%24%5Bbig%7D%20mountain/realy%20%231\'s.md')
+		expect(node.path).toBe('/~⛰️ shot of a $[big} mountain/realy #1\'s.md')
+		expect(node.dirname).toBe('/~⛰️ shot of a $[big} mountain')
 	})
 })
 

--- a/__tests__/files/file.spec.ts
+++ b/__tests__/files/file.spec.ts
@@ -9,6 +9,7 @@ describe('File creation', () => {
 	test('Valid dav file', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			mtime: new Date(Date.UTC(2023, 0, 1, 0, 0, 0)),
@@ -43,6 +44,7 @@ describe('File creation', () => {
 	test('Valid dav file with root', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			root: '/files/emma',
@@ -70,6 +72,7 @@ describe('File creation', () => {
 	test('Valid remote file', () => {
 		const file = new File({
 			source: 'https://domain.com/Photos/picture.jpg',
+			encodedSource: 'https://domain.com/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: null,
 		})
@@ -97,6 +100,7 @@ describe('File data change', () => {
 	test('Rename a file', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			mtime: new Date(Date.UTC(2023, 0, 1, 0, 0, 0)),
@@ -121,6 +125,7 @@ describe('File data change', () => {
 	test('Moving a file', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			mtime: new Date(Date.UTC(2023, 0, 1, 0, 0, 0)),
@@ -145,6 +150,7 @@ describe('File data change', () => {
 	test('Moving a file to an invalid destination throws', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			mtime: new Date(Date.UTC(2023, 0, 1, 0, 0, 0)),
@@ -157,6 +163,7 @@ describe('File data change', () => {
 	test('Moving a file to a different folder with root', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			root: '/files/emma',
@@ -177,6 +184,7 @@ describe('File data change', () => {
 	test('Changing status', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			root: '/files/emma',
@@ -192,6 +200,7 @@ describe('Altering attributes updates mtime', () => {
 	test('mtime is updated on existing attribute', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			mtime: new Date(Date.UTC(1990, 0, 1, 0, 0, 0)),
@@ -210,6 +219,7 @@ describe('Altering attributes updates mtime', () => {
 	test('mtime is updated on new attribute', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			mtime: new Date(Date.UTC(1990, 0, 1, 0, 0, 0)),
@@ -225,6 +235,7 @@ describe('Altering attributes updates mtime', () => {
 	test('mtime is updated on deleted attribute', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			mtime: new Date(Date.UTC(1990, 0, 1, 0, 0, 0)),
@@ -243,6 +254,7 @@ describe('Altering attributes updates mtime', () => {
 	test('mtime is NOT updated if not initially defined', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			attributes: {

--- a/__tests__/files/folder.spec.ts
+++ b/__tests__/files/folder.spec.ts
@@ -8,6 +8,7 @@ describe('Folder creation', () => {
 	test('Valid dav folder', () => {
 		const folder = new Folder({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/',
 			owner: 'emma',
 		})
 
@@ -32,6 +33,7 @@ describe('Folder creation', () => {
 	test('Valid dav folder with root', () => {
 		const folder = new Folder({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/Berlin',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/Berlin',
 			owner: 'emma',
 			root: '/files/emma',
 		})
@@ -57,6 +59,7 @@ describe('Folder creation', () => {
 	test('Valid remote folder', () => {
 		const folder = new Folder({
 			source: 'https://domain.com/Photos/',
+			encodedSource: 'https://domain.com/Photos/',
 			owner: null,
 		})
 
@@ -83,6 +86,7 @@ describe('Folder data change', () => {
 	test('Rename a folder', () => {
 		const folder = new Folder({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos',
 			owner: 'emma',
 		})
 
@@ -101,6 +105,7 @@ describe('Folder data change', () => {
 	test('Moving a folder', () => {
 		const folder = new Folder({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/',
 			owner: 'emma',
 		})
 
@@ -119,6 +124,7 @@ describe('Folder data change', () => {
 	test('Moving a folder to a different location with root', () => {
 		const folder = new Folder({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/',
 			owner: 'emma',
 			root: '/files/emma',
 		})

--- a/__tests__/files/node.spec.ts
+++ b/__tests__/files/node.spec.ts
@@ -10,6 +10,7 @@ describe('Node testing', () => {
 	test('Root null fallback', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 		})
@@ -19,6 +20,7 @@ describe('Node testing', () => {
 	test('Remove source ending slash', () => {
 		const file = new Folder({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
 			owner: 'emma',
 		})
 		expect(file.source).toBe('https://cloud.domain.com/remote.php/dav/files/emma/Photos')
@@ -27,6 +29,7 @@ describe('Node testing', () => {
 	test('Invalid rename', () => {
 		const file = new Folder({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
 			owner: 'emma',
 		})
 		expect(() => file.rename('new/folder')).toThrowError('Invalid basename')
@@ -37,6 +40,7 @@ describe('FileId attribute', () => {
 	test('FileId null fallback', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 		})
@@ -46,6 +50,7 @@ describe('FileId attribute', () => {
 	test('FileId null fallback', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			id: 1234,
@@ -57,6 +62,7 @@ describe('FileId attribute', () => {
 	test('FileId negative fallback', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			id: -1234,
@@ -67,6 +73,7 @@ describe('FileId attribute', () => {
 	test('FileId attributes fallback', () => {
 		const file = new Folder({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			attributes: {
@@ -81,6 +88,7 @@ describe('Sanity checks', () => {
 	test('Invalid id', () => {
 		expect(() => new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			id: '1234' as unknown as number,
@@ -91,24 +99,46 @@ describe('Sanity checks', () => {
 		expect(() => new File({} as unknown as NodeData)).toThrowError('Missing mandatory source')
 		expect(() => new File({
 			source: 'cloud.domain.com/remote.php/dav/Photos',
+			encodedSource: 'cloud.domain.com/remote.php/dav/Photos',
 			mime: 'image/jpeg',
 			owner: 'emma',
 		})).toThrowError('Invalid source')
 		expect(() => new File({
 			source: '/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: '/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 		})).toThrowError('Invalid source format, source must be a valid URL')
 		expect(() => new File({
 			source: 'ftp://remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'ftp://remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 		})).toThrowError('Invalid source format, only http(s) is supported')
 	})
 
+	test('Invalid encodedSource', () => {
+		expect(() => new File({
+			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+		} as unknown as NodeData)).toThrowError('Missing mandatory encodedSource')
+		expect(() => new File({
+			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: '/remote.php/dav/files/emma/Photos/picture.jpg',
+			mime: 'image/jpeg',
+			owner: 'emma',
+		})).toThrowError('Invalid encodedSource format, encodedSource must be a valid URL')
+		expect(() => new File({
+			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'ftp://remote.php/dav/files/emma/Photos/picture.jpg',
+			mime: 'image/jpeg',
+			owner: 'emma',
+		})).toThrowError('Invalid encodedSource format, only http(s) is supported')
+	})
+
 	test('Invalid mtime', () => {
 		expect(() => new File({
 			source: 'https://cloud.domain.com/remote.php/dav/Photos',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/Photos',
 			mime: 'image',
 			owner: 'emma',
 			mtime: 'invalid' as unknown as Date,
@@ -118,6 +148,7 @@ describe('Sanity checks', () => {
 	test('Invalid crtime', () => {
 		expect(() => new File({
 			source: 'https://cloud.domain.com/remote.php/dav/Photos',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/Photos',
 			mime: 'image',
 			owner: 'emma',
 			crtime: 'invalid' as unknown as Date,
@@ -127,6 +158,7 @@ describe('Sanity checks', () => {
 	test('Invalid mime', () => {
 		expect(() => new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image',
 			owner: 'emma',
 		})).toThrowError('Missing or invalid mandatory mime')
@@ -135,6 +167,7 @@ describe('Sanity checks', () => {
 	test('Invalid attributes', () => {
 		expect(() => new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			attributes: 'test' as unknown as Attribute,
@@ -144,6 +177,7 @@ describe('Sanity checks', () => {
 	test('Invalid permissions', () => {
 		expect(() => new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			permissions: 324 as unknown as number,
@@ -153,6 +187,7 @@ describe('Sanity checks', () => {
 	test('Invalid size', () => {
 		expect(() => new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			size: 'test' as unknown as number,
@@ -162,6 +197,7 @@ describe('Sanity checks', () => {
 	test('Invalid owner', () => {
 		expect(() => new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: true as unknown as string,
 		})).toThrowError('Invalid owner')
@@ -170,6 +206,7 @@ describe('Sanity checks', () => {
 	test('Invalid root', () => {
 		expect(() => new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			root: true as unknown as string,
@@ -177,6 +214,7 @@ describe('Sanity checks', () => {
 
 		expect(() => new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			root: 'https://cloud.domain.com/remote.php/dav/',
@@ -184,6 +222,7 @@ describe('Sanity checks', () => {
 
 		expect(() => new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			root: '/files/john',
@@ -191,6 +230,7 @@ describe('Sanity checks', () => {
 
 		expect(() => new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			root: '/remote.php/dav/files/emma',
@@ -200,6 +240,7 @@ describe('Sanity checks', () => {
 	test('Invalid status', () => {
 		expect(() => new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			status: 'invalid' as unknown as NodeStatus,
@@ -211,6 +252,7 @@ describe('Dav service detection', () => {
 	test('Known dav services', () => {
 		const file1 = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 		})
@@ -218,6 +260,7 @@ describe('Dav service detection', () => {
 
 		const file2 = new File({
 			source: 'https://cloud.domain.com/remote.php/webdav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/webdav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 		})
@@ -225,6 +268,7 @@ describe('Dav service detection', () => {
 
 		const file3 = new File({
 			source: 'https://cloud.domain.com/public.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/public.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 		})
@@ -232,6 +276,7 @@ describe('Dav service detection', () => {
 
 		const file4 = new File({
 			source: 'https://cloud.domain.com/public.php/webdav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/public.php/webdav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 		})
@@ -241,6 +286,7 @@ describe('Dav service detection', () => {
 	test('Custom dav service', () => {
 		const file1 = new File({
 			source: 'https://cloud.domain.com/test.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/test.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 		}, /test\.php\/dav/)
@@ -248,6 +294,7 @@ describe('Dav service detection', () => {
 
 		const file2 = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 		}, /test\.php\/dav/)
@@ -259,6 +306,7 @@ describe('Permissions handling', () => {
 	test('Default permissions', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 		})
@@ -268,6 +316,7 @@ describe('Permissions handling', () => {
 	test('Custom permissions', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			permissions: Permission.READ | Permission.UPDATE | Permission.CREATE | Permission.DELETE | Permission.SHARE,
@@ -280,6 +329,7 @@ describe('Root and paths detection', () => {
 	test('Unknown root', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 		})
@@ -290,6 +340,7 @@ describe('Root and paths detection', () => {
 	test('Provided root dav service', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			root: '/files/emma',
@@ -301,6 +352,7 @@ describe('Root and paths detection', () => {
 	test('Root with ending slash is removed', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			root: '/files/emma/',
@@ -313,6 +365,7 @@ describe('Root and paths detection', () => {
 	test('Root and source are the same', () => {
 		const folder = new Folder({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma',
+			encodedSource: 'https://cloud.domain.com/remote.php/dav/files/emma',
 			owner: 'emma',
 			root: '/files/emma',
 		})
@@ -324,6 +377,7 @@ describe('Root and paths detection', () => {
 	test('Source contains a similar root path', () => {
 		const folder = new Folder({
 			source: 'https://domain.com/remote.php/dav/files/emma/files/emma',
+			encodedSource: 'https://domain.com/remote.php/dav/files/emma/files/emma',
 			owner: 'emma',
 			root: '/files/emma',
 		})
@@ -333,6 +387,7 @@ describe('Root and paths detection', () => {
 
 		const file = new File({
 			source: 'https://domain.com/remote.php/dav/files/emma/files/emma.jpeg',
+			encodedSource: 'https://domain.com/remote.php/dav/files/emma/files/emma.jpeg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			root: '/files/emma',
@@ -345,6 +400,7 @@ describe('Root and paths detection', () => {
 	test('Non dav ressource with undefined root', () => {
 		const file = new File({
 			source: 'https://domain.com/files/images/emma.jpeg',
+			encodedSource: 'https://domain.com/files/images/emma.jpeg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 		})
@@ -359,6 +415,7 @@ describe('Undefined properties are allowed', () => {
 	test('File', () => {
 		expect(() => new File({
 			source: 'https://domain.com/files/images/emma.jpeg',
+			encodedSource: 'https://domain.com/files/images/emma.jpeg',
 			owner: 'emma',
 			id: undefined,
 			mtime: undefined,
@@ -375,6 +432,7 @@ describe('Undefined properties are allowed', () => {
 	test('Folder', () => {
 		expect(() => new Folder({
 			source: 'https://domain.com/files/images/',
+			encodedSource: 'https://domain.com/files/images/',
 			owner: 'emma',
 			id: undefined,
 			mtime: undefined,

--- a/__tests__/newFileMenu.spec.ts
+++ b/__tests__/newFileMenu.spec.ts
@@ -265,6 +265,7 @@ describe('NewFileMenu getEntries filter', () => {
 			owner: 'admin',
 			size: 2610077102,
 			source: 'https://example.com/remote.php/dav/files/admin/Folder',
+			encodedSource: 'https://example.com/remote.php/dav/files/admin/Folder',
 			permissions: Permission.ALL,
 		})
 
@@ -301,6 +302,7 @@ describe('NewFileMenu getEntries filter', () => {
 			owner: 'admin',
 			size: 2610077102,
 			source: 'https://example.com/remote.php/dav/files/admin/Folder',
+			encodedSource: 'https://example.com/remote.php/dav/files/admin/Folder',
 			permissions: Permission.READ,
 		})
 
@@ -334,6 +336,7 @@ describe('NewFileMenu getEntries filter', () => {
 			owner: 'admin',
 			size: 2610077102,
 			source: 'https://example.com/remote.php/dav/files/admin/Foo/Bar',
+			encodedSource: 'https://example.com/remote.php/dav/files/admin/Foo/Bar',
 			permissions: Permission.NONE,
 			root: '/files/admin',
 		})

--- a/lib/dav/dav.ts
+++ b/lib/dav/dav.ts
@@ -33,6 +33,7 @@ import { getCurrentUser, getRequestToken } from '@nextcloud/auth'
 import { generateRemoteUrl } from '@nextcloud/router'
 import { createClient, getPatcher, RequestOptions } from 'webdav'
 import { request } from 'webdav/dist/node/request.js'
+import { encodePath } from 'webdav/dist/node/tools/path.js'
 
 /**
  * Nextcloud DAV result response
@@ -132,6 +133,7 @@ export const davResultToNode = function(node: FileStat, filesRoot = davRootPath,
 	const nodeData: NodeData = {
 		id: (props?.fileid as number) || 0,
 		source: `${remoteURL}${node.filename}`,
+		encodedSource: `${remoteURL}${encodePath(node.filename)}`,
 		mtime: new Date(Date.parse(node.lastmod)),
 		mime: node.mime as string,
 		size: props?.size || Number.parseInt(props.getcontentlength || '0'),

--- a/lib/files/node.ts
+++ b/lib/files/node.ts
@@ -83,6 +83,14 @@ export abstract class Node {
 	}
 
 	/**
+	 * Get the encoded source url to this object
+	 */
+	get encodedSource(): string {
+		// strip any ending slash
+		return this._data.encodedSource.replace(/\/$/i, '')
+	}
+
+	/**
 	 * Get this object name
 	 */
 	get basename(): string {

--- a/lib/files/nodeData.ts
+++ b/lib/files/nodeData.ts
@@ -37,6 +37,13 @@ export interface NodeData {
 	 */
 	source: string
 
+	/**
+	 * Percent encoded URL to the ressource.
+	 * e.g. https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture_with_%23.jpg
+	 * or https://domain.com/Photos/picture_with_%23.jpg
+	 */
+	encodedSource: string
+
 	/** Last modified time */
 	mtime?: Date
 
@@ -94,6 +101,10 @@ export const validateData = (data: NodeData, davService: RegExp) => {
 		throw new Error('Missing mandatory source')
 	}
 
+	if (!data.encodedSource) {
+		throw new Error('Missing mandatory encodedSource')
+	}
+
 	try {
 		// eslint-disable-next-line no-new
 		new URL(data.source)
@@ -101,8 +112,19 @@ export const validateData = (data: NodeData, davService: RegExp) => {
 		throw new Error('Invalid source format, source must be a valid URL')
 	}
 
+	try {
+		// eslint-disable-next-line no-new
+		new URL(data.encodedSource)
+	} catch (e) {
+		throw new Error('Invalid encodedSource format, encodedSource must be a valid URL')
+	}
+
 	if (!data.source.startsWith('http')) {
 		throw new Error('Invalid source format, only http(s) is supported')
+	}
+
+	if (!data.encodedSource.startsWith('http')) {
+		throw new Error('Invalid encodedSource format, only http(s) is supported')
 	}
 
 	if (data.mtime && !(data.mtime instanceof Date)) {


### PR DESCRIPTION
After https://github.com/nextcloud/server/pull/40644 it's possible to delete, restore and favorite files with special characters like `#` but the displayed filenames are also encoded. 

This PR adds a new property `encodedSource` to handle it nicer.

I'm aware we could also split the given source uri and encode only the path. Such an approach will fail on some obscure uri we didn't think of and therefore the most reliable way for me is to let the caller generate the encoded source. 


