### PR TITLE
fix(Node): Handle slash as root path for public webdav endpoint

### DIFF
--- a/__tests__/files/node.spec.ts
+++ b/__tests__/files/node.spec.ts
@@ -298,6 +298,18 @@ describe('Root and paths detection', () => {
 		expect(file.dirname).toBe('/Photos')
 	})
 
+	test('Root with public webdav endpoint', () => {
+		const file = new File({
+			source: 'https://cloud.domain.com/public.php/webdav/Photos/picture.jpg',
+			mime: 'image/jpeg',
+			owner: 'emma',
+			root: '/',
+		})
+		expect(file.root).toBe('/')
+		expect(file.dirname).toBe('/Photos')
+		expect(file.path).toBe('/Photos/picture.jpg')
+	})
+
 	test('Root with ending slash is removed', () => {
 		const file = new File({
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',

--- a/lib/files/node.ts
+++ b/lib/files/node.ts
@@ -112,9 +112,16 @@ export abstract class Node {
 	 */
 	get dirname(): string {
 		if (this.root) {
+			let source = this.source
+			if (this.isDavRessource) {
+				// ensure we only work on the real path in case root is not distinct
+				source = source.split(this._knownDavService).pop()!
+			}
 			// Using replace would remove all part matching root
-			const firstMatch = this.source.indexOf(this.root)
-			return dirname(this.source.slice(firstMatch + this.root.length) || '/')
+			const firstMatch = source.indexOf(this.root)
+			// Ensure we do not remove the leading slash
+			const root = this.root.replace(/\/$/, '')
+			return dirname(source.slice(firstMatch + root.length) || '/')
 		}
 
 		// This should always be a valid URL
@@ -219,9 +226,16 @@ export abstract class Node {
 	 */
 	get path(): string {
 		if (this.root) {
+			let source = this.source
+			if (this.isDavRessource) {
+				// ensure we only work on the real path in case root is not distinct
+				source = source.split(this._knownDavService).pop()!
+			}
 			// Using replace would remove all part matching root
-			const firstMatch = this.source.indexOf(this.root)
-			return this.source.slice(firstMatch + this.root.length) || '/'
+			const firstMatch = source.indexOf(this.root)
+			// Ensure we do not remove the leading slash
+			const root = this.root.replace(/\/$/, '')
+			return source.slice(firstMatch + root.length) || '/'
 		}
 		return (this.dirname + '/' + this.basename).replace(/\/\//g, '/')
 	}


### PR DESCRIPTION
`dirname` and `path` both depend on the root property, but in case of the `webdav` endpoint the root is just `/` so in this case we need to remove the remote URL part first before we remove the root.

before | after
---|---
source: `http://foo.com/public.php/webdav/bar`<br>root: `/`<br>path: `/foo.com/public.php/webdav/bar`|source: `http://foo.com/public.php/webdav/bar`<br>root: `/`<br>path: `/bar`