### PR TITLE
chore: Prepare 3.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## 3.1.0 - 2023-12-21
+### Enhancements
+* enh(dav): Allow to set custom headers when creating the DAV client by @susnux in https://github.com/nextcloud-libraries/nextcloud-files/pull/849
+
+### Fixed
+* fix(Node): Handle slash as root path for public webdav endpoint by @susnux in https://github.com/nextcloud-libraries/nextcloud-files/pull/847
+* fix(dav): davResultToNode real owner by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-files/pull/862
+
+## Changed
+* Update webdav from 5.3.0 to 5.3.1
+* Update dev dependencies
+
 ## 3.0.0 - 2023-11-08
 
 ### Breaking

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/files",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/files",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/files",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Nextcloud files utils",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## 3.1.0 - 2023-12-21
### Enhancements
* enh(dav): Allow to set custom headers when creating the DAV client by @susnux in https://github.com/nextcloud-libraries/nextcloud-files/pull/849

### Fixed
* fix(Node): Handle slash as root path for public webdav endpoint by @susnux in https://github.com/nextcloud-libraries/nextcloud-files/pull/847
* fix(dav): davResultToNode real owner by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-files/pull/862

## Changed
* Update webdav from 5.3.0 to 5.3.1
* Update dev dependencies