### PR TITLE
fix(dav): remove sharing attributes from default dav fetch and change duplicate registration from `error` to `warn`

### DIFF
--- a/__tests__/dav/davProperties.spec.ts
+++ b/__tests__/dav/davProperties.spec.ts
@@ -19,6 +19,9 @@ describe('DAV Properties', () => {
 	beforeEach(() => {
 		delete window._nc_dav_properties
 		delete window._nc_dav_namespaces
+
+		logger.error = vi.fn()
+		logger.warn = vi.fn()
 	})
 
 	test('getDavNameSpaces fall back to defaults', () => {
@@ -51,54 +54,51 @@ describe('DAV Properties', () => {
 	})
 
 	test('registerDavProperty registers successfully', () => {
-		logger.error = vi.fn()
-
 		expect(window._nc_dav_namespaces).toBeUndefined()
 		expect(window._nc_dav_properties).toBeUndefined()
 
 		expect(registerDavProperty('my:prop', { my: 'https://example.com/ns' })).toBe(true)
+		expect(logger.warn).not.toBeCalled()
 		expect(logger.error).not.toBeCalled()
 		expect(getDavProperties().includes('my:prop')).toBe(true)
 		expect(getDavNameSpaces().includes('xmlns:my="https://example.com/ns"')).toBe(true)
 	})
 
-	test('registerDavProperty fails when registered multipletimes', () => {
-		logger.error = vi.fn()
-
+	test('registerDavProperty fails when registered multiple times', () => {
 		expect(window._nc_dav_namespaces).toBeUndefined()
 		expect(window._nc_dav_properties).toBeUndefined()
 
 		expect(registerDavProperty('my:prop', { my: 'https://example.com/ns' })).toBe(true)
 		expect(registerDavProperty('my:prop')).toBe(false)
-		expect(logger.error).toBeCalled()
+		expect(logger.warn).toBeCalled()
+		expect(logger.error).not.toBeCalled()
 		// but still included
 		expect(getDavProperties().includes('my:prop')).toBe(true)
 		expect(getDavNameSpaces().includes('xmlns:my="https://example.com/ns"')).toBe(true)
 	})
 
 	test('registerDavProperty fails with invalid props', () => {
-		logger.error = vi.fn()
-
 		expect(window._nc_dav_namespaces).toBeUndefined()
 		expect(window._nc_dav_properties).toBeUndefined()
 
 		expect(registerDavProperty('my:prop:invalid', { my: 'https://example.com/ns' })).toBe(false)
 		expect(logger.error).toBeCalled()
+		expect(logger.warn).not.toBeCalled()
 		expect(getDavProperties().includes('my:prop')).toBe(false)
 
 		expect(registerDavProperty('<my:prop />', { my: 'https://example.com/ns' })).toBe(false)
 		expect(logger.error).toBeCalled()
+		expect(logger.warn).not.toBeCalled()
 		expect(getDavProperties().includes('my:prop')).toBe(false)
 	})
 
 	test('registerDavProperty fails with missing namespace', () => {
-		logger.error = vi.fn()
-
 		expect(window._nc_dav_namespaces).toBeUndefined()
 		expect(window._nc_dav_properties).toBeUndefined()
 
 		expect(registerDavProperty('my:prop', { other: 'https://example.com/ns' })).toBe(false)
 		expect(logger.error).toBeCalled()
+		expect(logger.warn).not.toBeCalled()
 		expect(getDavProperties().includes('my:prop')).toBe(false)
 	})
 })

--- a/lib/dav/davProperties.ts
+++ b/lib/dav/davProperties.ts
@@ -35,16 +35,13 @@ export const defaultDavProperties = [
 	'nc:has-preview',
 	'nc:is-encrypted',
 	'nc:mount-type',
-	'nc:share-attributes',
 	'oc:comments-unread',
 	'oc:favorite',
 	'oc:fileid',
 	'oc:owner-display-name',
 	'oc:owner-id',
 	'oc:permissions',
-	'oc:share-types',
 	'oc:size',
-	'ocs:share-permissions',
 ]
 
 export const defaultDavNamespaces = {
@@ -72,7 +69,7 @@ export const registerDavProperty = function(prop: string, namespace: DavProperty
 
 	// Check duplicates
 	if (window._nc_dav_properties.find((search) => search === prop)) {
-		logger.error(`${prop} already registered`, { prop })
+		logger.warn(`${prop} already registered`, { prop })
 		return false
 	}
 


### PR DESCRIPTION
![image](https://github.com/nextcloud-libraries/nextcloud-files/assets/14975046/eafa1db9-e543-40a2-921e-3f844bfbd055)

We moved those attributes to the `files_sharing` app, since we can disable the app.

Fix https://github.com/nextcloud/server/issues/43953