### PR TITLE
feat(view): Allow reactive files view content

### DIFF
--- a/lib/navigation/view.ts
+++ b/lib/navigation/view.ts
@@ -30,6 +30,10 @@ export type ContentsWithRoot = {
 	contents: Node[]
 }
 
+interface CancellablePromise<T> extends Promise<T> {
+	cancel?: (reason?: unknown) => void
+}
+
 interface ViewData {
 	/** Unique view ID */
 	id: string
@@ -50,8 +54,10 @@ interface ViewData {
 	 * change and the promise is not resolved yet.
 	 * You _must_ also return the current directory
 	 * information alongside with its content.
+	 * @param path The current path in the view
+	 * @param onUpdate Optional callback to inform if the content changed since the last call
 	 */
-	getContents: (path: string) => Promise<ContentsWithRoot>
+	getContents: (path: string, onUpdate?: () => void) => CancellablePromise<ContentsWithRoot>
 	/** The view icon as an inline svg */
 	icon: string
 	/** The view order */


### PR DESCRIPTION
Allow views to accept a callback to call if the current content has changed (e.g. user settings etc).

For example if a view changed while the user is still on the same view, the files app content currently will not update.
This allows reactive content (another way would be to allow Vue reactive return values but this brings other problems as soon as files app and app registering the view have different Vue versions).

So a simple vanilla JS solution is to provide a callback to call when we need to inform the files app that the current view has changed and it needs to refetch the content.