### PR TITLE
fix(fileAction): cover parent getter in tests

### DIFF
--- a/__tests__/fileAction.spec.ts
+++ b/__tests__/fileAction.spec.ts
@@ -231,6 +231,7 @@ describe('FileActions creation', () => {
 			execBatch: async () => [true],
 			enabled: () => true,
 			order: 100,
+			parent: '123',
 			default: DefaultType.DEFAULT,
 			inline: () => true,
 			renderInline: async () => {
@@ -248,6 +249,7 @@ describe('FileActions creation', () => {
 		await expect(action.execBatch?.([], {} as any, '/')).resolves.toStrictEqual([true])
 		expect(action.enabled?.({} as any, {} as any)).toBe(true)
 		expect(action.order).toBe(100)
+		expect(action.parent).toBe('123')
 		expect(action.default).toBe(DefaultType.DEFAULT)
 		expect(action.inline?.({} as any, {} as any)).toBe(true)
 		expect((await action.renderInline?.({} as any, {} as any))?.outerHTML).toBe('<span>test</span>')


### PR DESCRIPTION
![image](https://github.com/nextcloud-libraries/nextcloud-files/assets/14975046/21b5489c-4ecf-4654-9f08-b2b6bd1ab87d)
This was bothering me :grin: 