### PR TITLE
chore: Prepare 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## 3.3.1 - 2024-05-23
+**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-files/compare/v3.3.0...v3.3.1
+
+### Fixed
+* fix: Export `NewMenuEntryCategory` from package by @susnux in https://github.com/nextcloud-libraries/nextcloud-files/pull/960
+
 ## 3.3.0 - 2024-05-21
-### Changed
+### Added
 * feat: Add and export `isFilenameValid` function by @susnux in https://github.com/nextcloud-libraries/nextcloud-files/pull/951
-* feat(ci): add codecov bundler by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-files/pull/948
 * feat(files): allow updating attributes by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-files/pull/947
 * feat(new-menu): Allow to set the category for entries by @susnux in https://github.com/nextcloud-libraries/nextcloud-files/pull/952
 
@@ -14,6 +19,9 @@ All notable changes to this project will be documented in this file.
 * fix(fileAction): cover parent getter in tests by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-files/pull/950
 * fix(navigation): files import by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-files/pull/949
 * fix(dav): Add fallback for owner of dav nodes on public shares by @susnux in https://github.com/nextcloud-libraries/nextcloud-files/pull/959
+
+### Changed
+* feat(ci): add codecov bundler by @skjnldsv in https://github.com/nextcloud-libraries/nextcloud-files/pull/948
 
 ### Dependencies
 * chore(deps): Bump @nextcloud/auth from 2.2.1 to 2.3.0 by @dependabot

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/files",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/files",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/files",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Nextcloud files utils",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## 3.3.1 - 2024-05-23
**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-files/compare/v3.3.0...v3.3.1

### Fixed
* fix: Export `NewMenuEntryCategory` from package by @susnux in https://github.com/nextcloud-libraries/nextcloud-files/pull/960
