### PR TITLE
fix(node): remove logger debug on attributes drop

### DIFF
--- a/lib/files/node.ts
+++ b/lib/files/node.ts
@@ -349,7 +349,6 @@ export abstract class Node {
 		const clean: Attribute = {}
 		for (const key in attributes) {
 			if (getters.includes(key)) {
-				logger.debug(`Discarding protected attribute ${key}`, { node: this, attributes })
 				continue
 			}
 			clean[key] = attributes[key]


### PR DESCRIPTION
This was a bit over the top :see_no_evil: 
![image](https://github.com/nextcloud-libraries/nextcloud-files/assets/14975046/5e9968e1-5f25-435e-9706-b64af2308286)
