### PR TITLE
fix(Node): Do not drop readonly attributes but only forbid updating them

### DIFF
--- a/__tests__/files/node.spec.ts
+++ b/__tests__/files/node.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import { File } from '../../lib/files/file'
 import { Folder } from '../../lib/files/folder'
@@ -546,6 +546,7 @@ describe('Attributes update', () => {
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
+			size: 9999,
 			attributes: {
 				etag: '1234',
 				size: 9999,
@@ -561,8 +562,41 @@ describe('Attributes update', () => {
 
 		expect(file.attributes?.etag).toBe('5678')
 		expect(file.attributes?.size).toBe(9999)
-		expect(file.attributes?.owner).toBeUndefined()
+		expect(file.attributes?.owner).toBe('emma')
 		expect(file.attributes?.fileid).toBeUndefined()
+	})
+
+	test('Deprecated access to toplevel attributes', () => {
+		const spy = vi.spyOn(window.console, 'warn')
+		const file = new File({
+			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			mime: 'image/jpeg',
+			owner: 'emma',
+			size: 9999,
+			attributes: {
+				etag: '1234',
+				size: 9999,
+			},
+		})
+
+		expect(file.attributes.size).toBe(9999)
+		expect(spy).toBeCalledTimes(1)
+	})
+
+	test('Changing a protected attributes is not possible', () => {
+		const file = new File({
+			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
+			mime: 'image/jpeg',
+			owner: 'emma',
+			attributes: {
+				etag: '1234',
+			},
+		})
+
+		// We can not update the owner
+		expect(() => { file.attributes.owner = 'admin' }).toThrowError()
+		// The owner is still the original one
+		expect(file.attributes?.owner).toBe('emma')
 	})
 
 })

--- a/__tests__/files/node.spec.ts
+++ b/__tests__/files/node.spec.ts
@@ -532,6 +532,8 @@ describe('Attributes update', () => {
 
 		file.update({
 			etag: '5678',
+			'owner-display-name': undefined,
+			'owner-id': undefined,
 		})
 
 		expect(file.attributes?.etag).toBe('5678')
@@ -546,6 +548,7 @@ describe('Attributes update', () => {
 			owner: 'emma',
 			attributes: {
 				etag: '1234',
+				size: 9999,
 			},
 		})
 
@@ -553,9 +556,11 @@ describe('Attributes update', () => {
 			etag: '5678',
 			owner: 'admin',
 			fileid: 1234,
+			size: undefined,
 		})
 
 		expect(file.attributes?.etag).toBe('5678')
+		expect(file.attributes?.size).toBe(9999)
 		expect(file.attributes?.owner).toBeUndefined()
 		expect(file.attributes?.fileid).toBeUndefined()
 	})


### PR DESCRIPTION
Attributes that are readonly should still be listed in the `attributes` getter, otherwise this is a hard breaking change as a lot of apps already depend on `attributes`. So instead only ensure that readonly attributes are skipped by the proxy handler.