### PR TITLE
feat: Export public interfaces of `Node`, `File` and `Folder`

### DIFF
--- a/lib/files/file.ts
+++ b/lib/files/file.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { FileType } from './fileType'
-import { Node } from './node'
+import { type INode, Node } from './node'
 
 export class File extends Node {
 
@@ -11,4 +11,11 @@ export class File extends Node {
 		return FileType.File
 	}
 
+}
+
+/**
+ * Interface of the File class
+ */
+export interface IFile extends INode {
+	readonly type: FileType.File
 }

--- a/lib/files/folder.ts
+++ b/lib/files/folder.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { FileType } from './fileType'
-import { Node } from './node'
-import { NodeData } from './nodeData'
+import { type INode, Node } from './node'
+import { type NodeData } from './nodeData'
 
 export class Folder extends Node {
 
@@ -28,4 +28,13 @@ export class Folder extends Node {
 		return 'httpd/unix-directory'
 	}
 
+}
+
+/**
+ * Interface of the folder class
+ */
+export interface IFolder extends INode {
+	readonly type: FileType.Folder
+	readonly extension: null
+	readonly mime: 'httpd/unix-directory'
 }

--- a/lib/files/node.ts
+++ b/lib/files/node.ts
@@ -358,3 +358,8 @@ export abstract class Node {
 	}
 
 }
+
+/**
+ * Interface of the node class
+ */
+export type INode = Pick<Node, keyof Node>

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -16,9 +16,9 @@ export * from './dav/davPermissions'
 export * from './dav/dav'
 
 export { FileType } from './files/fileType'
-export { File } from './files/file'
-export { Folder } from './files/folder'
-export { Node, NodeStatus } from './files/node'
+export { File, type IFile } from './files/file'
+export { Folder, type IFolder } from './files/folder'
+export { Node, NodeStatus, type INode } from './files/node'
 
 export { isFilenameValid, getUniqueName } from './utils/filename'
 export { formatFileSize, parseFileSize } from './utils/fileSize'

--- a/lib/navigation/column.ts
+++ b/lib/navigation/column.ts
@@ -2,8 +2,8 @@
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { View } from './view'
-import { Node } from '../files/node'
+import type { Node } from '../files/node'
+import type { View } from './view'
 
 interface ColumnData {
 	/** Unique column ID */

--- a/lib/navigation/navigation.ts
+++ b/lib/navigation/navigation.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { View } from './view'
+import type { View } from './view'
 import logger from '../utils/logger'
 
 export class Navigation {

--- a/lib/utils/fileSorting.ts
+++ b/lib/utils/fileSorting.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type { Node } from '../files/node'
+import type { INode } from '../files/node'
 import { orderBy } from './sorting'
 
 export enum FilesSortingMode {
@@ -41,7 +41,7 @@ export interface FilesSortingOptions {
  * @param nodes Nodes to sort
  * @param options Sorting options
  */
-export function sortNodes(nodes: readonly Node[], options: FilesSortingOptions = {}): Node[] {
+export function sortNodes(nodes: readonly INode[], options: FilesSortingOptions = {}): INode[] {
 	const sortingOptions = {
 		// Default to sort by name
 		sortingMode: FilesSortingMode.Name,
@@ -58,15 +58,15 @@ export function sortNodes(nodes: readonly Node[], options: FilesSortingOptions =
 
 	const identifiers = [
 		// 1: Sort favorites first if enabled
-		...(sortingOptions.sortFavoritesFirst ? [(v: Node) => v.attributes?.favorite !== 1] : []),
+		...(sortingOptions.sortFavoritesFirst ? [(v: INode) => v.attributes?.favorite !== 1] : []),
 		// 2: Sort folders first if sorting by name
-		...(sortingOptions.sortFoldersFirst ? [(v: Node) => v.type !== 'folder'] : []),
+		...(sortingOptions.sortFoldersFirst ? [(v: INode) => v.type !== 'folder'] : []),
 		// 3: Use sorting mode if NOT basename (to be able to use displayName too)
-		...(sortingOptions.sortingMode !== FilesSortingMode.Name ? [(v: Node) => v[sortingOptions.sortingMode]] : []),
+		...(sortingOptions.sortingMode !== FilesSortingMode.Name ? [(v: INode) => v[sortingOptions.sortingMode]] : []),
 		// 4: Use displayName if available, fallback to name
-		(v: Node) => basename(v.attributes?.displayName || v.basename),
+		(v: INode) => basename(v.attributes?.displayName || v.basename),
 		// 5: Finally, use basename if all previous sorting methods failed
-		(v: Node) => v.basename,
+		(v: INode) => v.basename,
 	]
 	const orders = [
 		// (for 1): always sort favorites before normal files


### PR DESCRIPTION
I would like to discuss this issue:


If you using those classes in Vue (e.g. in data) they will cause errors, as Vue unrefs data deeply and this causes all private fields to be stripped off from the interface. Passing one of those classes from data to a function that expects e.g. `Node` will then cause a Typescript error because the passed value is lacking the private fields.

So instead this provides interfaces that can be used whenever a parameter should be of one of those types.

Example of one of those errors:
![Screenshot_20240605_131335](https://github.com/nextcloud-libraries/nextcloud-files/assets/1855448/3ad39db9-8d37-44c2-9590-4630c2afdba5)

---

Alternative: Cast them every time you use them, like

```ts
data() {
  return { content: [] as Node[] }
},
methods: {
  handleConflicts() {
    getConflicts(nodes, this.content as Node[])
  },
},
```