### PR TITLE
fix(dav): Set `status` in `davResultToNode` when fileid is negative

### DIFF
--- a/__tests__/dav/dav.spec.ts
+++ b/__tests__/dav/dav.spec.ts
@@ -5,7 +5,7 @@
 import { afterAll, afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { readFile } from 'node:fs/promises'
 
-import { File, Folder, davRemoteURL, davGetFavoritesReport, davRootPath, getFavoriteNodes, davResultToNode } from '../../lib'
+import { File, Folder, davRemoteURL, davGetFavoritesReport, davRootPath, getFavoriteNodes, davResultToNode, NodeStatus } from '../../lib'
 import { FileStat } from 'webdav'
 import * as auth from '@nextcloud/auth'
 
@@ -134,6 +134,20 @@ describe('davResultToNode', () => {
 
 		expect(node.isDavRessource).toBe(true)
 		expect(node.owner).toBe('anonymous')
+	})
+
+	test('by default no status is set', () => {
+		const remoteResult = { ...result }
+		remoteResult.props!.fileid = 1
+		const node = davResultToNode(remoteResult)
+		expect(node.status).toBeUndefined()
+	})
+
+	test('sets node status on invalid fileid', () => {
+		const remoteResult = { ...result }
+		remoteResult.props!.fileid = -1
+		const node = davResultToNode(remoteResult)
+		expect(node.status).toBe(NodeStatus.FAILED)
 	})
 })
 

--- a/lib/dav/dav.ts
+++ b/lib/dav/dav.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import type { DAVResultResponseProps, FileStat, ResponseDataDetailed, WebDAVClient } from 'webdav'
-import type { Node } from '../files/node'
+import { NodeStatus, type Node } from '../files/node'
 
 import { File } from '../files/file'
 import { Folder } from '../files/folder'
@@ -148,13 +148,16 @@ export const davResultToNode = function(node: FileStat, filesRoot = davRootPath,
 	const props = node.props as ResponseProps
 	const permissions = davParsePermissions(props?.permissions)
 	const owner = String(props?.['owner-id'] || userId)
+	const id = props.fileid || 0
 
 	const nodeData: NodeData = {
-		id: props?.fileid || 0,
+		id,
 		source: `${remoteURL}${node.filename}`,
 		mtime: new Date(Date.parse(node.lastmod)),
 		mime: node.mime || 'application/octet-stream',
 		size: props?.size || Number.parseInt(props.getcontentlength || '0'),
+		// The fileid is set to -1 for failed requests
+		status: id < 0 ? NodeStatus.FAILED : undefined,
 		permissions,
 		owner,
 		root: filesRoot,


### PR DESCRIPTION
A negative fileid is returned by Nextcloud when something internally went wrong. In this case we should set the Node.status by default.