### PR TITLE
chore: Prepare release of v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## 3.5.0 - 2024-06-17
+**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-files/compare/v3.4.1...v3.5.0
+
+### Added
+* feat: Add filename util `getUniqueName` to generate a unique name \([\#986](https://github.com/nextcloud-libraries/nextcloud-files/pull/986)\)
+* feat: Export public interfaces of `Node`, `File` and `Folder` \([\#976](https://github.com/nextcloud-libraries/nextcloud-files/pull/976)\)
+* feat(navigation): Allow to listen for active navigation changes \([\#987](https://github.com/nextcloud-libraries/nextcloud-files/pull/987)\)
+
+### Fixed
+* fix(dav): Set `status` in `davResultToNode` when fileid is negative \([\#985](https://github.com/nextcloud-libraries/nextcloud-files/pull/985)\)
+* fix: When sorting by filename the extension should only be considered if the basename is equal \([\#984](https://github.com/nextcloud-libraries/nextcloud-files/pull/984)\)
+
+### Changed
+* Add SPDX headers \([\#980](https://github.com/nextcloud-libraries/nextcloud-files/pull/980)\)
+* Updated development dependencies
+
 ## 3.4.1 - 2024-06-05
 **Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-files/compare/v3.4.0...v3.4.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/files",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/files",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/files",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "Nextcloud files utils",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## 3.5.0 - 2024-06-17
**Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-files/compare/v3.4.1...v3.5.0

### Added
* feat: Add filename util `getUniqueName` to generate a unique name \([\#986](https://github.com/nextcloud-libraries/nextcloud-files/pull/986)\)
* feat: Export public interfaces of `Node`, `File` and `Folder` \([\#976](https://github.com/nextcloud-libraries/nextcloud-files/pull/976)\)
* feat(navigation): Allow to listen for active navigation changes \([\#987](https://github.com/nextcloud-libraries/nextcloud-files/pull/987)\)

### Fixed
* fix(dav): Set `status` in `davResultToNode` when fileid is negative \([\#985](https://github.com/nextcloud-libraries/nextcloud-files/pull/985)\)
* fix: When sorting by filename the extension should only be considered if the basename is equal \([\#984](https://github.com/nextcloud-libraries/nextcloud-files/pull/984)\)

### Changed
* Add SPDX headers \([\#980](https://github.com/nextcloud-libraries/nextcloud-files/pull/980)\)
* Updated development dependencies