### PR TITLE
fix(sorting): The display name attribute is called `displayname` not `displayName` for DAV

### DIFF
--- a/__tests__/utils/fileSorting.spec.ts
+++ b/__tests__/utils/fileSorting.spec.ts
@@ -74,7 +74,7 @@ describe('sortNodes', () => {
 				mtime: new Date(100),
 				size: 100,
 				attributes: {
-					displayName: 'a',
+					displayname: 'a',
 				},
 			}),
 			file('b', 100, 100),
@@ -95,7 +95,7 @@ describe('sortNodes', () => {
 				mtime: new Date(100),
 				size: 100,
 				attributes: {
-					displayName: 'a',
+					displayname: 'a',
 				},
 			}),
 			// File with basename "b" but displayname "a"
@@ -107,7 +107,7 @@ describe('sortNodes', () => {
 				mtime: new Date(100),
 				size: 100,
 				attributes: {
-					displayName: 'a',
+					displayname: 'a',
 				},
 			}),
 		]

--- a/lib/utils/fileSorting.ts
+++ b/lib/utils/fileSorting.ts
@@ -61,10 +61,10 @@ export function sortNodes(nodes: readonly INode[], options: FilesSortingOptions 
 		...(sortingOptions.sortFavoritesFirst ? [(v: INode) => v.attributes?.favorite !== 1] : []),
 		// 2: Sort folders first if sorting by name
 		...(sortingOptions.sortFoldersFirst ? [(v: INode) => v.type !== 'folder'] : []),
-		// 3: Use sorting mode if NOT basename (to be able to use displayName too)
+		// 3: Use sorting mode if NOT basename (to be able to use displayname too)
 		...(sortingOptions.sortingMode !== FilesSortingMode.Name ? [(v: INode) => v[sortingOptions.sortingMode]] : []),
-		// 4: Use displayName if available, fallback to name
-		(v: INode) => basename(v.attributes?.displayName || v.basename),
+		// 4: Use displayname if available, fallback to name
+		(v: INode) => basename(v.attributes?.displayname || v.basename),
 		// 5: Finally, use basename if all previous sorting methods failed
 		(v: INode) => v.basename,
 	]


### PR DESCRIPTION
Fix invalid usage of the display name property of DAV.