### PR TITLE
feat(node): Add `displayname` as top level attribute

### DIFF
--- a/__mocks__/@nextcloud/router.js
+++ b/__mocks__/@nextcloud/router.js
@@ -1,5 +1,6 @@
-/**
+/*!
  * SPDX-FileCopyrightText: 2022-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 export const generateRemoteUrl = (path) => `https://localhost/${path}`

--- a/__tests__/dav/dav.spec.ts
+++ b/__tests__/dav/dav.spec.ts
@@ -54,6 +54,7 @@ describe('davResultToNode', () => {
 	test('path does not contain root', () => {
 		const node = davResultToNode(result)
 		expect(node.basename).toBe(result.basename)
+		expect(node.displayname).toBe(result.props!.displayname)
 		expect(node.extension).toBe('.md')
 		expect(node.source).toBe('https://localhost/dav/files/test/New folder/Neue Textdatei.md')
 		expect(node.root).toBe(davRootPath)
@@ -83,6 +84,13 @@ describe('davResultToNode', () => {
 		expect(node.source).toBe('http://example.com/dav/root/New folder/Neue Textdatei.md')
 		expect(node.path).toBe('/New folder/Neue Textdatei.md')
 		expect(node.dirname).toBe('/New folder')
+	})
+
+	test('has correct displayname set', () => {
+		const remoteResult = { ...result, filename: '/root/New folder/Neue Textdatei.md' }
+		const node = davResultToNode(remoteResult, '/root', 'http://example.com/dav')
+		expect(node.basename).toBe(remoteResult.basename)
+		expect(node.displayname).toBe(remoteResult.props!.displayname)
 	})
 
 	// If owner-id is set, it will be used as owner

--- a/__tests__/files/node.spec.ts
+++ b/__tests__/files/node.spec.ts
@@ -208,6 +208,57 @@ describe('Permissions attribute', () => {
 	})
 })
 
+describe('Displayname attribute', () => {
+	test('legacy displayname attribute', () => {
+		// TODO: This logic can be removed with next major release (v4)
+		const file = new File({
+			source: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
+			mime: 'image/jpeg',
+			owner: 'emma',
+			attributes: {
+				displayname: 'image.png',
+			},
+		})
+		expect(file.basename).toBe('picture.jpg')
+		expect(file.displayname).toBe('image.png')
+		expect(file.attributes.displayname).toBe('image.png')
+	})
+
+	test('Read displayname attribute', () => {
+		const file = new File({
+			source: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
+			mime: 'image/jpeg',
+			owner: 'emma',
+			displayname: 'image.png',
+		})
+		expect(file.basename).toBe('picture.jpg')
+		expect(file.displayname).toBe('image.png')
+	})
+
+	test('Fallback displayname attribute', () => {
+		const file = new File({
+			source: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
+			mime: 'image/jpeg',
+			owner: 'emma',
+		})
+		expect(file.basename).toBe('picture.jpg')
+		expect(file.displayname).toBe('picture.jpg')
+	})
+
+	test('Set displayname attribute', () => {
+		const file = new File({
+			source: 'https://cloud.domain.com/remote.php/dav/picture.jpg',
+			mime: 'image/jpeg',
+			owner: 'emma',
+		})
+		expect(file.basename).toBe('picture.jpg')
+		expect(file.displayname).toBe('picture.jpg')
+
+		file.displayname = 'image.png'
+		expect(file.displayname).toBe('image.png')
+	})
+})
+
 describe('Sanity checks', () => {
 	test('Invalid id', () => {
 		expect(() => new File({
@@ -235,6 +286,15 @@ describe('Sanity checks', () => {
 			mime: 'image/jpeg',
 			owner: 'emma',
 		})).toThrowError('Invalid source format, only http(s) is supported')
+	})
+
+	test('Invalid displayname', () => {
+		expect(() => new File({
+			source: 'https://cloud.domain.com/remote.php/dav/Photos',
+			mime: 'image',
+			displayname: true as unknown as string,
+			owner: 'emma',
+		})).toThrowError('Invalid displayname type')
 	})
 
 	test('Invalid mtime', () => {
@@ -529,19 +589,17 @@ describe('Move and rename of a node', () => {
 	test('Move updates the fallback displayname', () => {
 		const file = new File({
 			source: 'https://cloud.example.com/dav/files/images/emma.jpeg',
+			displayname: 'emma.jpeg',
 			mime: 'image/jpeg',
 			owner: 'emma',
 			root: '/dav',
-			attributes: {
-				displayname: 'emma.jpeg',
-			},
 		})
 
 		expect(file.path).toBe('/files/images/emma.jpeg')
-		expect(file.attributes.displayname).toBe('emma.jpeg')
+		expect(file.displayname).toBe('emma.jpeg')
 		file.move('https://cloud.example.com/dav/files/pictures/jane.jpeg')
 		expect(file.path).toBe('/files/pictures/jane.jpeg')
-		expect(file.attributes.displayname).toBe('jane.jpeg')
+		expect(file.displayname).toBe('jane.jpeg')
 	})
 
 	test('Move does not updates custom displayname', () => {
@@ -550,16 +608,14 @@ describe('Move and rename of a node', () => {
 			mime: 'image/jpeg',
 			owner: 'emma',
 			root: '/dav',
-			attributes: {
-				displayname: 'profile.jpeg',
-			},
+			displayname: 'profile.jpeg',
 		})
 
 		expect(file.path).toBe('/files/images/emma.jpeg')
-		expect(file.attributes.displayname).toBe('profile.jpeg')
+		expect(file.displayname).toBe('profile.jpeg')
 		file.move('https://cloud.example.com/dav/files/pictures/jane.jpeg')
 		expect(file.path).toBe('/files/pictures/jane.jpeg')
-		expect(file.attributes.displayname).toBe('profile.jpeg')
+		expect(file.displayname).toBe('profile.jpeg')
 	})
 })
 

--- a/__tests__/utils/fileSorting.spec.ts
+++ b/__tests__/utils/fileSorting.spec.ts
@@ -71,11 +71,9 @@ describe('sortNodes', () => {
 				mime: 'text/plain',
 				// Resulting in name "d"
 				source: 'https://cloud.domain.com/remote.php/dav/d',
+				displayname: 'a',
 				mtime: new Date(100),
 				size: 100,
-				attributes: {
-					displayname: 'a',
-				},
 			}),
 			file('b', 100, 100),
 			file('c', 100, 500),
@@ -92,11 +90,9 @@ describe('sortNodes', () => {
 				mime: 'text/plain',
 				// Resulting in name "d"
 				source: 'https://cloud.domain.com/remote.php/dav/c',
+				displayname: 'a',
 				mtime: new Date(100),
 				size: 100,
-				attributes: {
-					displayname: 'a',
-				},
 			}),
 			// File with basename "b" but displayname "a"
 			new File({
@@ -104,11 +100,9 @@ describe('sortNodes', () => {
 				mime: 'text/plain',
 				// Resulting in name "d"
 				source: 'https://cloud.domain.com/remote.php/dav/b',
+				displayname: 'a',
 				mtime: new Date(100),
 				size: 100,
-				attributes: {
-					displayname: 'a',
-				},
 			}),
 		]
 

--- a/lib/dav/dav.ts
+++ b/lib/dav/dav.ts
@@ -179,6 +179,7 @@ export const davResultToNode = function(node: FileStat, filesRoot = davRootPath,
 		source: `${remoteURL}${node.filename}`,
 		mtime: new Date(Date.parse(node.lastmod)),
 		mime: node.mime || 'application/octet-stream',
+		displayname: props.displayname,
 		size: props?.size || Number.parseInt(props.getcontentlength || '0'),
 		// The fileid is set to -1 for failed requests
 		status: id < 0 ? NodeStatus.FAILED : undefined,

--- a/lib/files/nodeData.ts
+++ b/lib/files/nodeData.ts
@@ -39,6 +39,9 @@ export interface NodeData {
 	/** The owner  UID of this node */
 	owner: string|null
 
+	/** Optional the displayname of this node */
+	displayname?: string
+
 	/** The node attributes */
 	attributes?: Attribute
 
@@ -87,6 +90,10 @@ export const validateData = (data: NodeData, davService: RegExp) => {
 
 	if (!data.source.startsWith('http')) {
 		throw new Error('Invalid source format, only http(s) is supported')
+	}
+
+	if (data.displayname && typeof data.displayname !== 'string') {
+		throw new Error('Invalid displayname type')
 	}
 
 	if (data.mtime && !(data.mtime instanceof Date)) {


### PR DESCRIPTION
* chained on https://github.com/nextcloud-libraries/nextcloud-files/pull/1018

For legacy reasons a fallback is still used to move it from the `attributes` as otherwise this would be breaking.