### PR TITLE
refactor: Scope package into modules

### DIFF
--- a/__tests__/dav/davPermissions.spec.ts
+++ b/__tests__/dav/davPermissions.spec.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect } from 'vitest'
 
-import { davParsePermissions } from '../../lib/dav/davPermissions'
+import { parsePermissions } from '../../lib/dav/davPermissions'
 import { Permission } from '../../lib/permissions'
 
 const dataSet = [
@@ -30,7 +30,7 @@ describe('davParsePermissions', () => {
 	dataSet.forEach(({ input, permissions }) => {
 		it(`expect ${input} to be ${permissions}`, () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			expect(davParsePermissions(input as any as string)).toBe(permissions)
+			expect(parsePermissions(input as any as string)).toBe(permissions)
 		})
 	})
 })

--- a/__tests__/dav/davProperties.spec.ts
+++ b/__tests__/dav/davProperties.spec.ts
@@ -6,17 +6,24 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { XMLValidator } from 'fast-xml-parser'
 
 import {
-	davGetDefaultPropfind,
-	davGetFavoritesReport,
-	getDavNameSpaces,
-	getDavProperties,
-	registerDavProperty,
 	defaultDavNamespaces,
 	defaultDavProperties,
-	davGetRecentSearch,
+	getDavNameSpaces,
+	getDavProperties,
+	getDefaultPropfind,
+	getFavoritesReport,
+	getRecentSearch,
+	registerDavProperty,
 } from '../../lib/dav/davProperties'
 
 import logger from '../../lib/utils/logger'
+
+declare global {
+	interface Window {
+		_nc_dav_namespaces?: string[]
+		_nc_dav_properties?: string[]
+	}
+}
 
 describe('DAV Properties', () => {
 
@@ -42,19 +49,19 @@ describe('DAV Properties', () => {
 		defaultDavProperties.forEach(p => expect(props.includes(p)).toBe(true))
 	})
 
-	test('davGetDefaultPropfind', () => {
-		expect(typeof davGetDefaultPropfind()).toBe('string')
-		expect(XMLValidator.validate(davGetDefaultPropfind())).toBe(true)
+	test('getDefaultPropfind', () => {
+		expect(typeof getDefaultPropfind()).toBe('string')
+		expect(XMLValidator.validate(getDefaultPropfind())).toBe(true)
 	})
 
-	test('davGetFavoritesReport', () => {
-		expect(typeof davGetFavoritesReport()).toBe('string')
-		expect(XMLValidator.validate(davGetFavoritesReport())).toBe(true)
+	test('getFavoritesReport', () => {
+		expect(typeof getFavoritesReport()).toBe('string')
+		expect(XMLValidator.validate(getFavoritesReport())).toBe(true)
 	})
 
-	test('davGetFavoritesReport', () => {
-		expect(typeof davGetRecentSearch(1337)).toBe('string')
-		expect(XMLValidator.validate(davGetRecentSearch(1337))).toBe(true)
+	test('getFavoritesReport', () => {
+		expect(typeof getRecentSearch(1337)).toBe('string')
+		expect(XMLValidator.validate(getRecentSearch(1337))).toBe(true)
 	})
 
 	test('registerDavProperty registers successfully', () => {
@@ -116,7 +123,7 @@ describe('DAV Properties', () => {
 			'd:getetag',
 			'd:getlastmodified',
 			'd:resourcetype',
-			// Nextcloud autmatically includes:
+			// Nextcloud automatically includes:
 			// 'd:source'
 			// Only valid for GET requests
 			// 'd:getcontentlanguage',

--- a/__tests__/dav/public-shares.spec.ts
+++ b/__tests__/dav/public-shares.spec.ts
@@ -5,7 +5,7 @@
 
 import type { ArgumentsType } from 'vitest'
 import type { FileStat } from 'webdav'
-import type { davResultToNode } from '../../lib/dav/dav'
+import type { resultToNode as IResultToNode } from '../../lib/dav/dav'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 const auth = vi.hoisted(() => ({ getCurrentUser: vi.fn() }))
@@ -37,15 +37,15 @@ describe('DAV path functions', () => {
 	test('root path is correct on public shares', async () => {
 		mockPublicShare()
 
-		const { davGetRootPath } = await import('../../lib/dav/dav')
-		expect(davGetRootPath()).toBe('/files/token-1234')
+		const { getRootPath } = await import('../../lib/dav/dav')
+		expect(getRootPath()).toBe('/files/token-1234')
 	})
 
 	test('remote URL is correct on public shares', async () => {
 		mockPublicShare()
 
-		const { davGetRemoteURL } = await import('../../lib/dav/dav')
-		expect(davGetRemoteURL()).toBe('https://example.com/public.php/dav')
+		const { getRemoteURL } = await import('../../lib/dav/dav')
+		expect(getRemoteURL()).toBe('https://example.com/public.php/dav')
 	})
 })
 
@@ -56,9 +56,9 @@ describe('on public shares', () => {
 	})
 
 	// Wrapper function as we can not static import the function to allow mocking the modules
-	const resultToNode = async (...rest: ArgumentsType<typeof davResultToNode>) => {
-		const { davResultToNode } = await import('../../lib/dav/dav')
-		return davResultToNode(...rest)
+	const resultToNode = async (...rest: ArgumentsType<typeof IResultToNode>) => {
+		const { resultToNode } = await import('../../lib/dav/dav')
+		return resultToNode(...rest)
 	}
 
 	/*
@@ -83,7 +83,7 @@ describe('on public shares', () => {
 		},
 	}
 
-	describe('davResultToNode', () => {
+	describe('resultToNode', () => {
 		beforeEach(() => {
 			vi.resetModules()
 			restoreMocks()

--- a/lib/dav/davPermissions.ts
+++ b/lib/dav/davPermissions.ts
@@ -5,11 +5,11 @@
 import { Permission } from '../permissions'
 
 /**
- * Parse the webdav permission string to a permission enum
+ * Parse the WebDAV permission string to a permission enum
  *
  * @param permString The DAV permission string
  */
-export const davParsePermissions = function(permString = ''): number {
+export const parsePermissions = function(permString = ''): number {
 	let permissions = Permission.NONE
 
 	if (!permString) { return permissions }

--- a/lib/dav/davProperties.ts
+++ b/lib/dav/davProperties.ts
@@ -100,7 +100,7 @@ export const getDavNameSpaces = function(): string {
 /**
  * Get the default PROPFIND request body
  */
-export const davGetDefaultPropfind = function(): string {
+export const getDefaultPropfind = function(): string {
 	return `<?xml version="1.0"?>
 		<d:propfind ${getDavNameSpaces()}>
 			<d:prop>
@@ -112,7 +112,7 @@ export const davGetDefaultPropfind = function(): string {
 /**
  * Get the REPORT body to filter for favorite nodes
  */
-export const davGetFavoritesReport = function(): string {
+export const getFavoritesReport = function(): string {
 	return `<?xml version="1.0"?>
 		<oc:filter-files ${getDavNameSpaces()}>
 			<d:prop>
@@ -145,7 +145,7 @@ export const davGetFavoritesReport = function(): string {
  * }) as ResponseDataDetailed<FileStat[]>
  * ```
  */
-export const davGetRecentSearch = function(lastModified: number): string {
+export const getRecentSearch = function(lastModified: number): string {
 	return `<?xml version="1.0" encoding="UTF-8"?>
 <d:searchrequest ${getDavNameSpaces()}
 	xmlns:ns="https://github.com/icewind1991/SearchDAV/ns">

--- a/lib/dav/index.ts
+++ b/lib/dav/index.ts
@@ -1,0 +1,15 @@
+/*!
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * This module provides utils to work with the Nextcloud WebDAV interface.
+ *
+ * The DAV functions are based on the [`webdav`](https://www.npmjs.com/package/webdav) package.
+ * @packageDocumentation
+ */
+
+export * from './dav'
+export * from './davPermissions'
+export * from './davProperties'

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,10 +12,6 @@ export { Header, getFileListHeaders, registerFileListHeaders } from './fileListH
 export { type Entry, NewMenuEntryCategory } from './newFileMenu'
 export { Permission } from './permissions'
 
-export * from './dav/davProperties'
-export * from './dav/davPermissions'
-export * from './dav/dav'
-
 export { FileType } from './files/fileType'
 export { File, type IFile } from './files/file'
 export { Folder, type IFolder } from './files/folder'
@@ -69,3 +65,91 @@ export const getNewFileMenuEntries = function(context?: Folder) {
 		return a.displayName.localeCompare(b.displayName, undefined, { numeric: true, sensitivity: 'base' })
 	})
 }
+
+// Legacy export of dav utils
+// TODO: Remove with version 4 (breaking change)
+export {
+	type DavProperty,
+
+	/**
+	 * @inheritdoc
+	 * @deprecated use `defaultRemoteURL` from `@nextcloud/files/dav`
+	 */
+	defaultRemoteURL as davRemoteURL,
+	/**
+	 * @inheritdoc
+	 * @deprecated use `defaultRootPath` from `@nextcloud/files/dav`
+	 */
+	defaultRootPath as davRootPath,
+	/**
+	 * @inheritdoc
+	 * @deprecated use `defaultDavNamespaces` from `@nextcloud/files/dav`
+	 */
+	defaultDavNamespaces,
+	/**
+	 * @inheritdoc
+	 * @deprecated use `defaultDavProperties` from `@nextcloud/files/dav`
+	 */
+	defaultDavProperties,
+
+	/**
+	 * @inheritdoc
+	 * @deprecated use `getFavoriteNodes` from `@nextcloud/files/dav`
+	 */
+	getFavoriteNodes,
+	/**
+	 * @inheritdoc
+	 * @deprecated use `getClient` from `@nextcloud/files/dav`
+	 */
+	getClient as davGetClient,
+	/**
+	 * @inheritdoc
+	 * @deprecated use `getRemoteURL` from `@nextcloud/files/dav`
+	 */
+	getRemoteURL as davGetRemoteURL,
+	/**
+	 * @inheritdoc
+	 * @deprecated use `getRootPath` from `@nextcloud/files/dav`
+	 */
+	getRootPath as davGetRootPath,
+	/**
+	 * @inheritdoc
+	 * @deprecated use `resultToNode` from `@nextcloud/files/dav`
+	 */
+	resultToNode as davResultToNode,
+	/**
+	 * @inheritdoc
+	 * @deprecated use `getDefaultPropfind` from `@nextcloud/files/dav`
+	 */
+	getDefaultPropfind as davGetDefaultPropfind,
+	/**
+	 * @inheritdoc
+	 * @deprecated use `getFavoritesReport` from `@nextcloud/files/dav`
+	 */
+	getFavoritesReport as davGetFavoritesReport,
+	/**
+	 * @inheritdoc
+	 * @deprecated use `getRecentSearch` from `@nextcloud/files/dav`
+	 */
+	getRecentSearch as davGetRecentSearch,
+	/**
+	 * @inheritdoc
+	 * @deprecated use `parsePermissions` from `@nextcloud/files/dav`
+	 */
+	parsePermissions as davParsePermissions,
+	/**
+	 * @inheritdoc
+	 * @deprecated use `getDavNameSpaces` from `@nextcloud/files/dav`
+	 */
+	getDavNameSpaces,
+	/**
+	 * @inheritdoc
+	 * @deprecated use `getDavProperties` from `@nextcloud/files/dav`
+	 */
+	getDavProperties,
+	/**
+	 * @inheritdoc
+	 * @deprecated use `registerDavProperty` from `@nextcloud/files/dav`
+	 */
+	registerDavProperty,
+} from './dav/index'

--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
+    },
+    "./dav": {
+      "types": "./dist/dav.d.ts",
+      "import": "./dist/dav.mjs",
+      "require": "./dist/dav.cjs"
     }
   },
   "files": [
@@ -29,7 +34,7 @@
   ],
   "scripts": {
     "build": "vite --mode production build",
-    "build:doc": "typedoc && touch dist/doc/.nojekyll",
+    "build:doc": "typedoc --out dist/doc lib/dav/index.ts lib/index.ts && touch dist/doc/.nojekyll",
     "dev": "vite --mode development build",
     "watch": "vite --mode development build --watch",
     "lint": "eslint .",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,8 +7,12 @@ import { createLibConfig } from '@nextcloud/vite-config'
 
 export default createLibConfig({
 	index: 'lib/index.ts',
+	dav: 'lib/dav/index.ts',
 }, {
-	libraryFormats: ['es', 'cjs'],
+	libraryFormats: ['cjs', 'es'],
+
+	DTSPluginOptions: { rollupTypes: true },
+
 	nodeExternalsOptions: {
 		// Force bundle pure ESM module
 		exclude: ['is-svg'],


### PR DESCRIPTION
What do you think of this idea?

---

* Implements: https://github.com/nextcloud-libraries/nextcloud-files/issues/1015

This splits the package into modules:
1. The default one (`@nextcloud/files`) which provides general classes to work with the Node classes we use nearly everywhere
2. DAV utils (`@nextcloud/files/dav`) which provides WebDAV related utils
3. File list related utils (actions, filters, columns)
4. Navigation related utils
5. General purpose small helper functions (utils)

For legacy reasons to not make this a breaking release the DAV utils are exported with their prefixed names in the default module, but this will be then removed with the next major version.