### PR TITLE
fix: Correctly export public API

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,7 +23,7 @@ export { Node, NodeStatus, type INode } from './files/node'
 export * from './utils/filename-validation'
 export { getUniqueName } from './utils/filename'
 export { formatFileSize, parseFileSize } from './utils/fileSize'
-export { orderBy } from './utils/sorting'
+export { orderBy, type SortingOrder } from './utils/sorting'
 export { sortNodes, FilesSortingMode, type FilesSortingOptions } from './utils/fileSorting'
 
 export * from './navigation/navigation'

--- a/lib/utils/fileSorting.ts
+++ b/lib/utils/fileSorting.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import type { INode } from '../files/node'
+import type { SortingOrder } from './sorting'
 import { orderBy } from './sorting'
 
 export enum FilesSortingMode {
@@ -21,7 +22,7 @@ export interface FilesSortingOptions {
 	/**
 	 * @default 'asc'
 	 */
-	sortingOrder?: 'asc'|'desc'
+	sortingOrder?: SortingOrder
 
 	/**
 	 * If set to true nodes marked as favorites are ordered on top of all other nodes
@@ -61,9 +62,9 @@ export function sortNodes(nodes: readonly INode[], options: FilesSortingOptions 
 		...(sortingOptions.sortFavoritesFirst ? [(v: INode) => v.attributes?.favorite !== 1] : []),
 		// 2: Sort folders first if sorting by name
 		...(sortingOptions.sortFoldersFirst ? [(v: INode) => v.type !== 'folder'] : []),
-		// 3: Use sorting mode if NOT basename (to be able to use displayname too)
+		// 3: Use sorting mode if NOT basename (to be able to use display name too)
 		...(sortingOptions.sortingMode !== FilesSortingMode.Name ? [(v: INode) => v[sortingOptions.sortingMode]] : []),
-		// 4: Use displayname if available, fallback to name
+		// 4: Use display name if available, fallback to name
 		(v: INode) => basename(v.attributes?.displayname || v.basename),
 		// 5: Finally, use basename if all previous sorting methods failed
 		(v: INode) => v.basename,

--- a/lib/utils/sorting.ts
+++ b/lib/utils/sorting.ts
@@ -5,7 +5,7 @@
 import { getCanonicalLocale, getLanguage } from '@nextcloud/l10n'
 
 type IdentifierFn<T> = (v: T) => unknown
-type SortingOrder = 'asc'|'desc'
+export type SortingOrder = 'asc'|'desc'
 
 /**
  * Helper to create string representation


### PR DESCRIPTION
Use sorting order consistently and export it as it is part of the public API.