### PR TITLE
fix(dav): Cast displayname to string in `resultToNode`

### DIFF
--- a/lib/dav/dav.ts
+++ b/lib/dav/dav.ts
@@ -179,7 +179,8 @@ export const davResultToNode = function(node: FileStat, filesRoot = davRootPath,
 		source: `${remoteURL}${node.filename}`,
 		mtime: new Date(Date.parse(node.lastmod)),
 		mime: node.mime || 'application/octet-stream',
-		displayname: props.displayname,
+		// Manually cast to work around for https://github.com/perry-mitchell/webdav-client/pull/380
+		displayname: props.displayname !== undefined ? String(props.displayname) : undefined,
 		size: props?.size || Number.parseInt(props.getcontentlength || '0'),
 		// The fileid is set to -1 for failed requests
 		status: id < 0 ? NodeStatus.FAILED : undefined,


### PR DESCRIPTION
There is a bug in the webdav library that will cause e.g. `1` as a name to be interpreted as the number 1.