### PR TITLE
chore: Prepare v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## 3.7.0 - 2024-07-25
+[Full changelog](https://github.com/nextcloud-libraries/nextcloud-files/compare/v3.6.0...v3.7.0)
+
+### Added
+* feat: Implement API for file list filters [\#1027](https://github.com/nextcloud-libraries/nextcloud-files/pull/1027) \([susnux](https://github.com/susnux)\)
+
+### Fixed
+* fix(dav): Cast displayname to string in `resultToNode` [\#1028](https://github.com/nextcloud-libraries/nextcloud-files/pull/1028) \([susnux](https://github.com/susnux)\)
+* fix: Correctly export public API [\#1026](https://github.com/nextcloud-libraries/nextcloud-files/pull/1026) \([susnux](https://github.com/susnux)\)
+
+### Changed
+* chore(deps): Bump @nextcloud/paths from 2.1.0 to 2.2.0
+
 ## 3.6.0 - 2024-07-18
 [Full Changelog](https://github.com/nextcloud-libraries/nextcloud-files/compare/v3.5.1...v3.6.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/files",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/files",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/files",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Nextcloud files utils",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## 3.7.0 - 2024-07-25
[Full changelog](https://github.com/nextcloud-libraries/nextcloud-files/compare/v3.6.0...v3.7.0)

### Added
* feat: Implement API for file list filters [\#1027](https://github.com/nextcloud-libraries/nextcloud-files/pull/1027) \([susnux](https://github.com/susnux)\)

### Fixed
* fix(dav): Cast displayname to string in `resultToNode` [\#1028](https://github.com/nextcloud-libraries/nextcloud-files/pull/1028) \([susnux](https://github.com/susnux)\)
* fix: Correctly export public API [\#1026](https://github.com/nextcloud-libraries/nextcloud-files/pull/1026) \([susnux](https://github.com/susnux)\)

### Changed
* chore(deps): Bump @nextcloud/paths from 2.1.0 to 2.2.0