### PR TITLE
fix!: Allow to inherit from `View` to create custom classes

### DIFF
--- a/__tests__/fileListHeaders.spec.ts
+++ b/__tests__/fileListHeaders.spec.ts
@@ -2,13 +2,12 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable no-new */
 import { describe, expect, test, beforeEach, vi } from 'vitest'
 
 import { Folder } from '../lib/files/folder'
 import { Header, getFileListHeaders, registerFileListHeaders } from '../lib/fileListHeaders'
+import { View } from '../lib/navigation/view'
 import logger from '../lib/utils/logger'
 
 describe('FileListHeader init', () => {
@@ -37,7 +36,7 @@ describe('FileListHeader init', () => {
 
 		expect(header.id).toBe('test')
 		expect(header.order).toBe(1)
-		expect(header.enabled!({} as Folder, {})).toBe(true)
+		expect(header.enabled!({} as Folder, {} as View)).toBe(true)
 
 		registerFileListHeaders(header)
 
@@ -103,7 +102,7 @@ describe('FileListHeader validate', () => {
 				id: null,
 				render: () => {},
 				updated: () => {},
-			} as any as Header)
+			} as unknown as Header)
 		}).toThrowError('Invalid header: id, render and updated are required')
 
 		expect(() => {
@@ -111,7 +110,7 @@ describe('FileListHeader validate', () => {
 				id: '123',
 				render: null,
 				updated: () => {},
-			} as any as Header)
+			} as unknown as Header)
 		}).toThrowError('Invalid header: id, render and updated are required')
 
 		expect(() => {
@@ -119,7 +118,7 @@ describe('FileListHeader validate', () => {
 				id: '123',
 				render: () => {},
 				updated: null,
-			} as any as Header)
+			} as unknown as Header)
 		}).toThrowError('Invalid header: id, render and updated are required')
 	})
 	test('Invalid id', () => {
@@ -128,7 +127,7 @@ describe('FileListHeader validate', () => {
 				id: true,
 				render: () => {},
 				updated: () => {},
-			} as any as Header)
+			} as unknown as Header)
 		}).toThrowError('Invalid id property')
 	})
 	test('Invalid enabled', () => {
@@ -138,7 +137,7 @@ describe('FileListHeader validate', () => {
 				enabled: true,
 				render: () => {},
 				updated: () => {},
-			} as any as Header)
+			} as unknown as Header)
 		}).toThrowError('Invalid enabled property')
 	})
 	test('Invalid render', () => {
@@ -148,7 +147,7 @@ describe('FileListHeader validate', () => {
 				enabled: () => {},
 				render: true,
 				updated: () => {},
-			} as any as Header)
+			} as unknown as Header)
 		}).toThrowError('Invalid render property')
 	})
 	test('Invalid updated', () => {
@@ -158,7 +157,7 @@ describe('FileListHeader validate', () => {
 				enabled: () => {},
 				render: () => {},
 				updated: true,
-			} as any as Header)
+			} as unknown as Header)
 		}).toThrowError('Invalid updated property')
 	})
 })
@@ -182,9 +181,9 @@ describe('FileListHeader exec', () => {
 		expect(header.render).toBe(render)
 		expect(header.updated).toBe(updated)
 
-		header.enabled!({} as Folder, {})
-		header.render(null as any as HTMLElement, {} as Folder, {})
-		header.updated({} as Folder, {})
+		header.enabled!({} as Folder, {} as View)
+		header.render({} as HTMLElement, {} as Folder, {} as View)
+		header.updated({} as Folder, {} as View)
 
 		expect(enabled).toHaveBeenCalled()
 		expect(render).toHaveBeenCalled()

--- a/__tests__/navigation/navigation.spec.ts
+++ b/__tests__/navigation/navigation.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { describe, it, expect, vi } from 'vitest'
-import { Navigation, getNavigation } from '../lib/navigation/navigation'
-import { View } from '../lib/navigation/view'
+import { Navigation, getNavigation } from '../../lib/navigation/navigation'
+import { View } from '../../lib/navigation/view'
 
 const mockView = (id = 'view', order = 1) => new View({ id, order, name: 'View', icon: '<svg></svg>', getContents: () => Promise.reject(new Error()) })
 

--- a/__tests__/navigation/view.spec.ts
+++ b/__tests__/navigation/view.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { describe, expect, test } from 'vitest'
+import { ContentsWithRoot, View, ViewData } from '../../lib/navigation/view'
+import { Folder, Navigation } from '../../lib'
+
+// This is used for testing that users can implement their own views which have access
+// to `this` for allowing private state
+class MyView extends View {
+
+	public testing = false
+
+	constructor() {
+		super({
+			id: 'my-view',
+			name: 'My view',
+			icon: '<svg></svg>',
+		} as ViewData)
+	}
+
+	public async getContents(path: string): Promise<ContentsWithRoot> {
+		this.testing = true
+		return {
+			folder: new Folder({
+				owner: 'foo',
+				source: `http://example.com/src/${path}`,
+				root: '/src',
+			}),
+			contents: [],
+		}
+	}
+
+}
+
+describe('Custom view', () => {
+
+	test('Can inherite from the View class', () => {
+		// eslint-disable-next-line no-new
+		expect(() => new MyView()).not.toThrow()
+	})
+
+	test('Custom view classes have "this" context', () => {
+		const view = new MyView()
+		expect(view.testing).toBe(false)
+		view.getContents('/')
+		expect(view.testing).toBe(true)
+	})
+
+	test('Can register custom view', () => {
+		const view = new MyView()
+		const navigation = new Navigation()
+		expect(() => navigation.register(view)).not.toThrow()
+		expect(navigation.views.length).toBe(1)
+	})
+
+})

--- a/lib/navigation/view.ts
+++ b/lib/navigation/view.ts
@@ -13,7 +13,7 @@ export type ContentsWithRoot = {
 	contents: Node[]
 }
 
-interface ViewData {
+export interface ViewData {
 	/** Unique view ID */
 	id: string
 	/** Translated view name */
@@ -27,7 +27,7 @@ interface ViewData {
 	emptyCaption?: string
 
 	/**
-	 * Method return the content of the  provided path
+	 * Method return the content of the provided path
 	 * This ideally should be a cancellable promise.
 	 * promise.cancel(reason) will be called when the directory
 	 * change and the promise is not resolved yet.
@@ -35,6 +35,7 @@ interface ViewData {
 	 * information alongside with its content.
 	 */
 	getContents: (path: string) => Promise<ContentsWithRoot>
+
 	/** The view icon as an inline svg */
 	icon: string
 
@@ -86,8 +87,13 @@ export class View implements ViewData {
 
 	private _view: ViewData
 
+	// TODO: This should not be a constructor but a static method like `fromData` or similar
+	// instead the constructor should be private so we can just inherit from this class without need of validation
 	constructor(view: ViewData) {
-		isValidView(view)
+		// second parameter is checking if **this** class is just View or a child class,
+		// this is needed because child classes can implement `getContents` as a method
+		// so they would not pass it to the ViewData - but this should only allowed from a child constructor
+		isValidView(view, Object.getPrototypeOf(this) === View.prototype)
 		this._view = view
 	}
 
@@ -111,8 +117,11 @@ export class View implements ViewData {
 		return this._view.emptyCaption
 	}
 
-	get getContents() {
-		return this._view.getContents
+	getContents(path: string) {
+		if (!this._view.getContents) {
+			throw new Error('When inheriting the `View` class you need to implement the `getContents` method!')
+		}
+		return this._view.getContents(path)
 	}
 
 	get icon() {
@@ -143,8 +152,17 @@ export class View implements ViewData {
 		return this._view.columns
 	}
 
-	get emptyView() {
-		return this._view.emptyView
+	/**
+	 * True if this view provides a custom empty view, false otherwise.
+	 */
+	get hasEmptyView(): boolean {
+		return this._view.emptyView !== undefined
+	}
+
+	emptyView(div: HTMLDivElement) {
+		if (this._view.emptyView) {
+			this._view.emptyView(div)
+		}
 	}
 
 	get parent() {
@@ -167,8 +185,11 @@ export class View implements ViewData {
 		return this._view.defaultSortKey
 	}
 
-	get loadChildViews() {
-		return this._view.loadChildViews
+	loadChildViews(view: View) {
+		if (this._view.loadChildViews) {
+			return this._view.loadChildViews(view)
+		}
+		return Promise.resolve()
 	}
 
 }
@@ -177,11 +198,12 @@ export class View implements ViewData {
  * Typescript cannot validate an interface.
  * Please keep in sync with the View interface requirements.
  *
- * @param {ViewData} view the view to check
+ * @param view the view to check
+ * @param strict if this validation should be strict (check all props)
  * @return {boolean} true if the column is valid
  * @throws {Error} if the view is not valid
  */
-const isValidView = function(view: ViewData): boolean {
+const isValidView = function(view: ViewData, strict = true): boolean {
 	if (!view.id || typeof view.id !== 'string') {
 		throw new Error('View id is required and must be a string')
 	}
@@ -195,7 +217,9 @@ const isValidView = function(view: ViewData): boolean {
 		throw new Error('View caption is required for top-level views and must be a string')
 	}
 
-	if (!view.getContents || typeof view.getContents !== 'function') {
+	// If the view is a child class of View getContents could be a member function
+	// so it would not be part of the ViewData
+	if (strict && (!view.getContents || typeof view.getContents !== 'function')) {
 		throw new Error('View getContents is required and must be a function')
 	}
 
@@ -203,7 +227,7 @@ const isValidView = function(view: ViewData): boolean {
 		throw new Error('View icon is required and must be a valid svg string')
 	}
 
-	if ('order' in view && typeof view.order !== 'number') {
+	if (view.order !== undefined && typeof view.order !== 'number') {
 		throw new Error('View order must be a number')
 	}
 
@@ -224,11 +248,11 @@ const isValidView = function(view: ViewData): boolean {
 		throw new Error('View parent must be a string')
 	}
 
-	if ('sticky' in view && typeof view.sticky !== 'boolean') {
+	if (view.sticky !== undefined && typeof view.sticky !== 'boolean') {
 		throw new Error('View sticky must be a boolean')
 	}
 
-	if ('expanded' in view && typeof view.expanded !== 'boolean') {
+	if (view.expanded !== undefined && typeof view.expanded !== 'boolean') {
 		throw new Error('View expanded must be a boolean')
 	}
 


### PR DESCRIPTION
Use case:
You want to scope logic and state into the view rather than somewhere in a module.

Problems:
Currently there are two problem that prevent creating a child-class of view:
1. The view class did not implement the methods as methods but getters, this forces also child classes to use getters leading to really ugly code.
2. The constructor required `getContents` to be part of the `ViewData`, but for child classes this makes no sense, as you probably want to overwrite this with a member function instead. Fixed by checking if `new View` was called or a new subclass.