### PR TITLE
fix: Make `View` methods bound to `ViewData` object

### DIFF
--- a/__tests__/navigation/navigation.spec.ts
+++ b/__tests__/navigation/navigation.spec.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { describe, it, expect, vi } from 'vitest'
-import { Navigation, getNavigation } from '../lib/navigation/navigation'
-import { View } from '../lib/navigation/view'
+import { Navigation, getNavigation } from '../../lib/navigation/navigation'
+import { View } from '../../lib/navigation/view'
 
 const mockView = (id = 'view', order = 1) => new View({ id, order, name: 'View', icon: '<svg></svg>', getContents: () => Promise.reject(new Error()) })
 

--- a/__tests__/navigation/view.spec.ts
+++ b/__tests__/navigation/view.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { describe, expect, test } from 'vitest'
+import { ContentsWithRoot, View, type ViewData } from '../../lib/navigation/view'
+import { Folder, Navigation } from '../../lib'
+
+// This is used for testing that users can implement their own views which have access
+// to `this` for allowing private state
+class MyView implements ViewData {
+
+	public readonly id = 'my-view'
+	public readonly name = 'My view'
+	public readonly icon = '<svg></svg>'
+
+	public async getContents(): Promise<ContentsWithRoot> {
+		return {
+			folder: this.getFolder(),
+			contents: [],
+		}
+	}
+
+	private getFolder() {
+		return new Folder({
+			owner: 'test',
+			source: 'http://example.com/remote.php/dav/root/folder',
+			root: '/root',
+		})
+	}
+
+}
+
+describe('Custom view', () => {
+
+	test('Can pass class as view data', () => {
+		// eslint-disable-next-line no-new
+		expect(() => new View(new MyView())).not.toThrow()
+	})
+
+	test('Custom view classes have "this" context', async () => {
+		const view = new View(new MyView())
+		const response = await view.getContents('/')
+		// did not throw yet
+
+		expect(response.folder).toBeInstanceOf(Folder)
+		expect(response.folder.owner).toBe('test')
+	})
+
+	test('Can register custom view', () => {
+		const view = new View(new MyView())
+		const navigation = new Navigation()
+		expect(() => navigation.register(view)).not.toThrow()
+		expect(navigation.views.length).toBe(1)
+	})
+
+})

--- a/lib/navigation/view.ts
+++ b/lib/navigation/view.ts
@@ -13,7 +13,7 @@ export type ContentsWithRoot = {
 	contents: Node[]
 }
 
-interface ViewData {
+export interface ViewData {
 	/** Unique view ID */
 	id: string
 	/** Translated view name */
@@ -77,6 +77,7 @@ interface ViewData {
 
 	/**
 	 * Method called to load child views if any
+	 * @param view This view (deprecated use `this` instead)
 	 */
 	// eslint-disable-next-line no-use-before-define
 	loadChildViews?: (view: View) => Promise<void>
@@ -112,7 +113,7 @@ export class View implements ViewData {
 	}
 
 	get getContents() {
-		return this._view.getContents
+		return this._view.getContents.bind(this._view)
 	}
 
 	get icon() {
@@ -144,7 +145,7 @@ export class View implements ViewData {
 	}
 
 	get emptyView() {
-		return this._view.emptyView
+		return this._view.emptyView?.bind(this._view)
 	}
 
 	get parent() {
@@ -168,7 +169,7 @@ export class View implements ViewData {
 	}
 
 	get loadChildViews() {
-		return this._view.loadChildViews
+		return this._view.loadChildViews?.bind(this._view)
 	}
 
 }


### PR DESCRIPTION
Use case:
You want to scope logic and state into the view rather than somewhere in a module.

Problem:
The `View` class wraps the `ViewData` as a getter, meaning instead of calling the function on the object, it just returns the reference to the function within the object. This means the function looses the reference to the object as `this`.

---

* This is an alternative for https://github.com/nextcloud-libraries/nextcloud-files/pull/1067

Instead of making `View` a real class that can be extended, this just allows to use stateful `ViewData`.
Meaning function like `getContents` and `loadChildView` do not loose the `this` context, but can still work with it.
This is useful to have stateful views, e.g. the favorites view which needs to load children based on a state (nodes added / removed).