### PR TITLE
feat: Add `reset` method to file list filters

### DIFF
--- a/__tests__/fileListFilter.spec.ts
+++ b/__tests__/fileListFilter.spec.ts
@@ -64,6 +64,20 @@ describe('File list filter class', () => {
 		const filter = new TestFilter('my:id')
 		expect(() => filter.filter([])).toThrowError()
 	})
+
+	test('emits chips updated event', () => {
+		const filter = new TestFilter('my:id', 50)
+		const chips: IFileListFilterChip[] = [{ text: 'my chip', onclick: () => {} }]
+		const spy = vi.fn()
+
+		filter.addEventListener('update:chips', spy)
+		filter.testUpdateChips(chips)
+
+		expect(spy).toBeCalled()
+		expect(spy.mock.calls[0][0]).toBeInstanceOf(CustomEvent)
+		expect(spy.mock.calls[0][0].type).toBe('update:chips')
+		expect(spy.mock.calls[0][0].detail).toBe(chips)
+	})
 })
 
 describe('File list filter functions', () => {

--- a/lib/fileListFilters.ts
+++ b/lib/fileListFilters.ts
@@ -68,15 +68,27 @@ export interface IFileListFilter extends TypedEventTarget<IFileListFilterEvents>
 	readonly order: number
 
 	/**
-	 * If the filter needs a visual element for settings it can provide a function to mount it.
+	 * Filter function to decide if a node is shown.
+	 *
+	 * @param nodes Nodes to filter
+	 * @return Subset of the `nodes` parameter to show
 	 */
-	readonly mount?: (el: HTMLElement) => void
+	filter(nodes: INode[]): INode[]
 
 	/**
-	 * Filter function to decide if a node is shown
-	 * @return The nodes to be shown
+	 * If the filter needs a visual element for settings it can provide a function to mount it.
+	 * @param el The DOM element to mount to
 	 */
-	filter(node: INode[]): INode[]
+	mount?(el: HTMLElement): void
+
+	/**
+	 * Reset the filter to the initial state.
+	 * This is called by the files app.
+	 * Implementations should make sure,that if they provide chips they need to emit the `update:chips` event.
+	 *
+	 * @since 3.10.0
+	 */
+	reset?(): void
 }
 
 export class FileListFilter extends TypedEventTarget<IFileListFilterEvents> implements IFileListFilter {


### PR DESCRIPTION
This allows the files app to reset filters if needed (e.g. on navigation) instead all filters to listen  to different events.