### PR TITLE
fix: Node imports paths

### DIFF
--- a/__tests__/dav/dav.spec.ts
+++ b/__tests__/dav/dav.spec.ts
@@ -4,6 +4,9 @@
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { readFile } from 'node:fs/promises'
+// required as default URL will be the DOM URL class which will use the window.location
+import { URL as FileURL } from 'node:url'
+import * as auth from '@nextcloud/auth'
 
 import {
 	defaultRemoteURL,
@@ -12,12 +15,11 @@ import {
 	getFavoriteNodes,
 	resultToNode,
 } from '../../lib/dav/index'
-import { File, Folder, NodeStatus } from '../../lib'
-import { FileStat } from 'webdav'
-import * as auth from '@nextcloud/auth'
 
-// required as default URL will be the DOM URL class which will use the window.location
-import { URL as FileURL } from 'node:url'
+import { File } from '../../lib/files/file'
+import { FileStat } from 'webdav'
+import { Folder } from '../../lib/files/folder'
+import { NodeStatus } from '../../lib/files/node'
 
 vi.mock('@nextcloud/auth')
 vi.mock('@nextcloud/router')

--- a/__tests__/fileListAction.spec.ts
+++ b/__tests__/fileListAction.spec.ts
@@ -5,11 +5,11 @@
 
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
-import type { View } from '../lib/navigation/view.ts'
+import type { View } from '../lib/navigation/view'
 
-import { getFileListActions, registerFileListAction, FileListAction } from '../lib/fileListAction.ts'
-import { Folder } from '../lib/files/folder.ts'
-import logger from '../lib/utils/logger.ts'
+import { getFileListActions, registerFileListAction, FileListAction } from '../lib/fileListAction'
+import { Folder } from '../lib/files/folder'
+import logger from '../lib/utils/logger'
 
 const mockAction = (id: string) => new FileListAction({
 	id,

--- a/__tests__/view.spec.ts
+++ b/__tests__/view.spec.ts
@@ -5,8 +5,8 @@
 
 import { describe, expect, test } from 'vitest'
 
-import { View } from '../lib/navigation/view.ts'
-import { Folder } from '../lib/index.ts'
+import { View } from '../lib/navigation/view'
+import { Folder } from '../lib/files/folder'
 
 describe('Invalid View creation', () => {
 	test('Invalid id', () => {

--- a/lib/dav/dav.ts
+++ b/lib/dav/dav.ts
@@ -12,10 +12,10 @@ import { NodeData } from '../files/nodeData'
 import { parsePermissions } from './davPermissions'
 import { getFavoritesReport } from './davProperties'
 
-import { getCurrentUser, getRequestToken, onRequestTokenUpdate } from '@nextcloud/auth'
-import { generateRemoteUrl } from '@nextcloud/router'
 import { CancelablePromise } from 'cancelable-promise'
 import { createClient, getPatcher } from 'webdav'
+import { generateRemoteUrl } from '@nextcloud/router'
+import { getCurrentUser, getRequestToken, onRequestTokenUpdate } from '@nextcloud/auth'
 import { getSharingToken, isPublicShare } from '@nextcloud/sharing/public'
 
 /**
@@ -201,5 +201,5 @@ export const resultToNode = function(node: FileStat, filesRoot = defaultRootPath
 
 	delete nodeData.attributes?.props
 
-	return node.type === 'file' ? new File(nodeData) : new Folder(nodeData)
+	return (node.type === 'file' ? new File(nodeData) : new Folder(nodeData)) as Node
 }

--- a/lib/fileAction.ts
+++ b/lib/fileAction.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { Node } from './files/node'
-import { View } from './navigation/view'
+import type { Node } from './files/node'
+import type { View } from './navigation/view'
 import logger from './utils/logger'
 
 export enum DefaultType {

--- a/lib/fileListAction.ts
+++ b/lib/fileListAction.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { Node } from './files/node.ts'
-import { Folder } from './files/folder.ts'
-import { View } from './navigation/view.ts'
-import logger from './utils/logger.ts'
+import type { Node } from './files/node'
+import type { Folder } from './files/folder'
+import type { View } from './navigation/view'
+import logger from './utils/logger'
 
 interface ActionContext {
 	folder: Folder,

--- a/lib/fileListFilters.ts
+++ b/lib/fileListFilters.ts
@@ -5,7 +5,7 @@
 
 import { emit } from '@nextcloud/event-bus'
 import { TypedEventTarget } from 'typescript-event-target'
-import { INode } from './files/node'
+import { Node } from './files/node'
 
 /**
  * Active filters can provide one or more "chips" to show the currently active state.
@@ -73,7 +73,7 @@ export interface IFileListFilter extends TypedEventTarget<IFileListFilterEvents>
 	 * @param nodes Nodes to filter
 	 * @return Subset of the `nodes` parameter to show
 	 */
-	filter(nodes: INode[]): INode[]
+	filter(nodes: Node[]): Node[]
 
 	/**
 	 * If the filter needs a visual element for settings it can provide a function to mount it.
@@ -103,7 +103,7 @@ export class FileListFilter extends TypedEventTarget<IFileListFilterEvents> impl
 		this.order = order
 	}
 
-	public filter(nodes: INode[]): INode[] {
+	public filter(nodes: Node[]): Node[] {
 		throw new Error('Not implemented')
 		return nodes
 	}

--- a/lib/newFileMenu.ts
+++ b/lib/newFileMenu.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type { Folder, Node } from './index'
+import type { Node } from './files/node'
+import type { Folder } from './files/folder'
 import logger from './utils/logger'
 
 export enum NewMenuEntryCategory {

--- a/lib/utils/fileSorting.ts
+++ b/lib/utils/fileSorting.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import type { INode } from '../files/node'
+import type { Node } from '../files/node'
 import type { SortingOrder } from './sorting'
 import { orderBy } from './sorting'
 
@@ -42,7 +42,7 @@ export interface FilesSortingOptions {
  * @param nodes Nodes to sort
  * @param options Sorting options
  */
-export function sortNodes(nodes: readonly INode[], options: FilesSortingOptions = {}): INode[] {
+export function sortNodes(nodes: readonly Node[], options: FilesSortingOptions = {}): Node[] {
 	const sortingOptions = {
 		// Default to sort by name
 		sortingMode: FilesSortingMode.Name,
@@ -59,15 +59,15 @@ export function sortNodes(nodes: readonly INode[], options: FilesSortingOptions 
 
 	const identifiers = [
 		// 1: Sort favorites first if enabled
-		...(sortingOptions.sortFavoritesFirst ? [(v: INode) => v.attributes?.favorite !== 1] : []),
+		...(sortingOptions.sortFavoritesFirst ? [(v: Node) => v.attributes?.favorite !== 1] : []),
 		// 2: Sort folders first if sorting by name
-		...(sortingOptions.sortFoldersFirst ? [(v: INode) => v.type !== 'folder'] : []),
+		...(sortingOptions.sortFoldersFirst ? [(v: Node) => v.type !== 'folder'] : []),
 		// 3: Use sorting mode if NOT basename (to be able to use display name too)
-		...(sortingOptions.sortingMode !== FilesSortingMode.Name ? [(v: INode) => v[sortingOptions.sortingMode]] : []),
+		...(sortingOptions.sortingMode !== FilesSortingMode.Name ? [(v: Node) => v[sortingOptions.sortingMode]] : []),
 		// 4: Use display name if available, fallback to name
-		(v: INode) => basename(v.displayname || v.attributes?.displayname || v.basename),
+		(v: Node) => basename(v.displayname || v.attributes?.displayname || v.basename),
 		// 5: Finally, use basename if all previous sorting methods failed
-		(v: INode) => v.basename,
+		(v: Node) => v.basename,
 	]
 	const orders = [
 		// (for 1): always sort favorites before normal files

--- a/window.d.ts
+++ b/window.d.ts
@@ -7,7 +7,7 @@
 import type { IFileListFilter, Navigation } from './lib'
 import type { DavProperty } from './lib/dav/davProperties'
 import type { FileAction } from './lib/fileAction'
-import type { FileListAction } from './lib/fileListAction.ts'
+import type { FileListAction } from './lib/fileListAction'
 import type { Header } from './lib/fileListHeaders'
 import type { NewFileMenu } from './lib/newFileMenu'
 


### PR DESCRIPTION
Might fix https://github.com/nextcloud-libraries/nextcloud-files/issues/1127

- [x] Always import type when necessary (not the full declaration)
- [x] always import from the real ts file, not from `lib/index.ts`