### PR TITLE
fix: Do not rollup types

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,8 +11,6 @@ export default createLibConfig({
 }, {
 	libraryFormats: ['cjs', 'es'],
 
-	DTSPluginOptions: { rollupTypes: true },
-
 	nodeExternalsOptions: {
 		// Force bundle pure ESM module
 		exclude: ['is-svg'],


### PR DESCRIPTION
* fix: https://github.com/nextcloud-libraries/nextcloud-files/issues/1127

The rollup only works for single entry point and will duplicate declarations.
See: https://api-extractor.com/pages/setup/configure_rollup/#an-important-limitation