### PR TITLE
fix: Correctly export DAV types

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
       "require": "./dist/index.cjs"
     },
     "./dav": {
-      "types": "./dist/dav.d.ts",
+      "types": "./dist/dav/index.d.ts",
       "import": "./dist/dav.mjs",
       "require": "./dist/dav.cjs"
     }


### PR DESCRIPTION
* Resolves https://github.com/nextcloud-libraries/nextcloud-files/issues/1174