### PR TITLE
fix: do not update mtime on move/rename

### DIFF
--- a/__tests__/files/file.spec.ts
+++ b/__tests__/files/file.spec.ts
@@ -103,13 +103,11 @@ describe('File data change', () => {
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
-			mtime: new Date(Date.UTC(2023, 0, 1, 0, 0, 0)),
 		})
 
 		expect(file.basename).toBe('picture.jpg')
 		expect(file.dirname).toBe('/')
 		expect(file.root).toBe('/files/emma/Photos')
-		expect(file.mtime?.toISOString()).toBe('2023-01-01T00:00:00.000Z')
 
 		file.rename('picture-old.jpg')
 
@@ -117,9 +115,6 @@ describe('File data change', () => {
 		expect(file.dirname).toBe('/')
 		expect(file.source).toBe('https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture-old.jpg')
 		expect(file.root).toBe('/files/emma/Photos')
-
-		// Check that mtime has been updated
-		expect(file.mtime?.getDate()).toBe(new Date().getDate())
 	})
 
 	test('Moving a file', () => {
@@ -127,13 +122,11 @@ describe('File data change', () => {
 			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
 			mime: 'image/jpeg',
 			owner: 'emma',
-			mtime: new Date(Date.UTC(2023, 0, 1, 0, 0, 0)),
 		})
 
 		expect(file.basename).toBe('picture.jpg')
 		expect(file.dirname).toBe('/')
 		expect(file.root).toBe('/files/emma/Photos')
-		expect(file.mtime?.toISOString()).toBe('2023-01-01T00:00:00.000Z')
 
 		file.move('https://cloud.domain.com/remote.php/dav/files/emma/Pictures/picture-old.jpg')
 
@@ -141,9 +134,6 @@ describe('File data change', () => {
 		expect(file.dirname).toBe('/')
 		expect(file.source).toBe('https://cloud.domain.com/remote.php/dav/files/emma/Pictures/picture-old.jpg')
 		expect(file.root).toBe('/files/emma/Pictures')
-
-		// Check that mtime has been updated
-		expect(file.mtime?.getDate()).toBe(new Date().getDate())
 	})
 
 	test('Moving a file to an invalid destination throws', () => {

--- a/__tests__/files/node.spec.ts
+++ b/__tests__/files/node.spec.ts
@@ -640,7 +640,6 @@ describe('Root and paths detection', () => {
 })
 
 describe('Move and rename of a node', () => {
-
 	test('Move updates the basename', () => {
 		const file = new File({
 			source: 'https://cloud.example.com/dav/files/images/emma.jpeg',

--- a/lib/files/node.ts
+++ b/lib/files/node.ts
@@ -372,7 +372,6 @@ export abstract class Node {
 			// this can not be guaranteed, so to be sure users should better refetch the node
 			this.displayname = this.basename
 		}
-		this.updateMtime()
 	}
 
 	/**


### PR DESCRIPTION
Our storage backend doesn't update it.
We have a discrepancy. 

So if I rename a file, which changes the last mtime with the current state of this library, then updating from the backend again (refreshing for example) shows the old date again.