### PR TITLE
fix(sorting): also check attributes

### DIFF
--- a/__tests__/utils/fileSorting.spec.ts
+++ b/__tests__/utils/fileSorting.spec.ts
@@ -2,10 +2,12 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+import type { Attribute } from '../../lib/files/nodeData'
+
 import { ArgumentsType, describe, expect, test } from 'vitest'
 import { File, FilesSortingMode, Folder, sortNodes as originalSortNodes } from '../../lib'
 
-const file = (name: string, size?: number, modified?: number, favorite = false) => new File({
+const file = (name: string, size?: number, modified?: number, favorite = false, attributes: Attribute = {}) => new File({
 	source: `https://cloud.domain.com/remote.php/dav/${name}`,
 	mime: 'text/plain',
 	owner: 'jdoe',
@@ -15,7 +17,7 @@ const file = (name: string, size?: number, modified?: number, favorite = false) 
 		? {
 			favorite: 1,
 		}
-		: undefined,
+		: attributes,
 })
 
 const folder = (name: string, size?: number, modified?: number, favorite = false) => new Folder({
@@ -284,5 +286,15 @@ describe('sortNodes', () => {
 				},
 			),
 		).toEqual(['file.a', 'file.b', 'file.c', 'file.d'])
+	})
+
+	test('Can sort by random attribute', () => {
+		const array = [
+			file('a', 500, 100, false, { order: 3 }),
+			file('b', 100, 100, false, { order: 2 }),
+			file('c', 100, 500, false, { order: 1 }),
+		]
+
+		expect(sortNodes(array, { sortingMode: 'order' })).toEqual(['c', 'b', 'a'])
 	})
 })

--- a/lib/dav/dav.ts
+++ b/lib/dav/dav.ts
@@ -156,7 +156,7 @@ export const getFavoriteNodes = (davClient: WebDAVClient, path = '/', davRoot = 
 }
 
 /**
- * Covert DAV result `FileStat` to `Node`
+ * Convert DAV result `FileStat` to `Node`
  *
  * @param node The DAV result
  * @param filesRoot The DAV files root path

--- a/lib/utils/fileSorting.ts
+++ b/lib/utils/fileSorting.ts
@@ -17,7 +17,7 @@ export interface FilesSortingOptions {
 	 * They key to order the files by
 	 * @default FilesSortingMode.Name
 	 */
-	sortingMode?: FilesSortingMode
+	sortingMode?: FilesSortingMode | string
 
 	/**
 	 * @default 'asc'
@@ -63,7 +63,7 @@ export function sortNodes(nodes: readonly INode[], options: FilesSortingOptions 
 		// 2: Sort folders first if sorting by name
 		...(sortingOptions.sortFoldersFirst ? [(v: INode) => v.type !== 'folder'] : []),
 		// 3: Use sorting mode if NOT basename (to be able to use display name too)
-		...(sortingOptions.sortingMode !== FilesSortingMode.Name ? [(v: INode) => v[sortingOptions.sortingMode]] : []),
+		...(sortingOptions.sortingMode !== FilesSortingMode.Name ? [(v: INode) => v[sortingOptions.sortingMode] || v.attributes[sortingOptions.sortingMode]] : []),
 		// 4: Use display name if available, fallback to name
 		(v: INode) => basename(v.displayname || v.attributes?.displayname || v.basename || ''),
 		// 5: Finally, use basename if all previous sorting methods failed


### PR DESCRIPTION
Needed for https://github.com/nextcloud/server/issues/49140
Because the Trashbin view use a custom attribute key to sort https://github.com/nextcloud/server/blob/aac5859444a54e9774b794ad4b29486bbb384ea7/apps/files_trashbin/src/files_views/trashbinView.ts#L26