### PR TITLE
chore: work around bug in `corepack` blocking dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,10 +81,12 @@
     "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "devEngines": {
-    "packageManager": {
-      "name": "npm",
-      "version": "^10.0.0"
-    },
+    "packageManager": [
+      {
+        "name": "npm",
+        "version": "^10.0.0"
+      }
+    ],
     "runtime": {
       "name": "node",
       "version": "^22.0.0"


### PR DESCRIPTION
dependabot uses `corepack` for all updates of node dependencies. The problem here is that `corepack` breaks if the
`devEngines.packageManager` does not define a **full semantic version** meaning it does not support semantic ranges.
We can work around this by just using the array syntax with only one entry.

For reference the *corepack* bug report: https://github.com/nodejs/corepack/issues/729