### PR TITLE
fix: Handle snowflake-ids

### DIFF
--- a/__tests__/files/node.spec.ts
+++ b/__tests__/files/node.spec.ts
@@ -302,15 +302,6 @@ describe('Displayname attribute', () => {
 })
 
 describe('Sanity checks', () => {
-	test('Invalid id', () => {
-		expect(() => new File({
-			source: 'https://cloud.domain.com/remote.php/dav/files/emma/Photos/picture.jpg',
-			mime: 'image/jpeg',
-			owner: 'emma',
-			id: '1234' as unknown as number,
-		})).toThrowError('Invalid id type of value')
-	})
-
 	test('Invalid source', () => {
 		expect(() => new File({} as unknown as NodeData)).toThrowError('Missing mandatory source')
 		expect(() => new Folder({

--- a/lib/node/nodeData.ts
+++ b/lib/node/nodeData.ts
@@ -12,7 +12,7 @@ export interface Attribute { [key: string]: any }
 
 export interface NodeData {
 	/** Unique ID */
-	id?: number
+	id?: number|string
 
 	/**
 	 * URL to the resource.
@@ -73,7 +73,7 @@ export const isDavResource = function(source: string, davService: RegExp): boole
  * @param davService Pattern to check if source is DAV ressource
  */
 export const validateData = (data: NodeData, davService: RegExp) => {
-	if (data.id && typeof data.id !== 'number') {
+	if (data.id && typeof data.id !== 'number' && typeof data.id !== 'string') {
 		throw new Error('Invalid id type of value')
 	}
 


### PR DESCRIPTION
With snowflake-ids, we get numbers represented as strings as ids.

Not tested, as I couldn't figure out how to use a patched version in server but this should fix the CI failure on https://github.com/nextcloud/server/pull/56183