### PR TITLE
fix(upload): properly handle skipped files

### DIFF
--- a/lib/upload/uploader/UploadFile.spec.ts
+++ b/lib/upload/uploader/UploadFile.spec.ts
@@ -183,6 +183,41 @@ describe('upload status and events', () => {
 		expect(onFinish).toHaveBeenCalledOnce()
 	})
 
+	it('keeps the source unencoded but encodes the request URL', async () => {
+		isPublicShareMock.mockReturnValue(false)
+		getMaxChunksSizeMock.mockReturnValue(0)
+		uploadDataMock.mockImplementationOnce(() => Promise.resolve())
+
+		const uploadFile = new UploadFile('/destination/a b&c.txt', new File(['x'], 'a b&c.txt'), { noChunking: true })
+		const queue = { add: vi.fn((fn: () => Promise<void>) => fn()) }
+
+		await uploadFile.start(queue as never)
+		await queue.add.mock.calls[0][0]()
+
+		expect(uploadFile.source).toBe('/destination/a b&c.txt')
+		expect(uploadDataMock).toHaveBeenCalledWith('/destination/a%20b%26c.txt', expect.anything(), expect.anything())
+	})
+
+	it('encodes the destination header of chunked uploads', async () => {
+		isPublicShareMock.mockReturnValue(false)
+		getMaxChunksSizeMock.mockReturnValue(1024)
+		initChunkWorkspaceMock.mockResolvedValue('/tmp/temporary')
+		uploadDataMock.mockImplementation(() => Promise.resolve())
+		const requestSpy = vi.spyOn(axios, 'request').mockResolvedValueOnce({} as never)
+
+		const uploadFile = new UploadFile('/destination/a b&c.txt', new File(['x'.repeat(4096)], 'a b&c.txt'), { noChunking: false })
+		const queue = { add: vi.fn((fn: () => Promise<void>) => fn()) }
+
+		await uploadFile.start(queue as never)
+		await Promise.all(queue.add.mock.results.map((r) => r.value))
+
+		expect(uploadFile.source).toBe('/destination/a b&c.txt')
+		// the workspace is created with the encoded destination
+		expect(initChunkWorkspaceMock).toHaveBeenCalledWith('/destination/a%20b%26c.txt', 5, false, {})
+		// … and so is the assemble request
+		expect(requestSpy.mock.lastCall![0].headers!.Destination).toBe('/destination/a%20b%26c.txt')
+	})
+
 	it('scheduled', async () => {
 		isPublicShareMock.mockReturnValue(false)
 		getMaxChunksSizeMock.mockReturnValue(1024)

--- a/lib/upload/uploader/UploadFile.ts
+++ b/lib/upload/uploader/UploadFile.ts
@@ -14,6 +14,7 @@ import { UploadFailedError } from '../errors/UploadFailedError.ts'
 import { getMaxChunksSize, supportsPublicChunking } from '../utils/config.ts'
 import { getMtimeHeader, isRequestAborted } from '../utils/requests.ts'
 import { getChunk, initChunkWorkspace, uploadData } from '../utils/upload.ts'
+import { encodeUrl } from '../utils/url.ts'
 import { Upload, UploadStatus } from './Upload.ts'
 
 /**
@@ -101,7 +102,7 @@ export class UploadFile extends Upload implements IUpload {
 		this.status = UploadStatus.UPLOADING
 		const chunk = await getChunk(this.#file!, 0, this.#file!.size)
 		try {
-			await this.#uploadChunk(chunk, this.source)
+			await this.#uploadChunk(chunk, encodeUrl(this.source))
 		} catch (error) {
 			if (!(error instanceof UploadCancelledError)) {
 				throw error
@@ -118,7 +119,9 @@ export class UploadFile extends Upload implements IUpload {
 	 */
 	async #uploadChunked(queue: PQueue) {
 		this.status = UploadStatus.UPLOADING
-		const temporaryUrl = await initChunkWorkspace(this.source, 5, isPublicShare(), this.#customHeaders)
+		// The `Destination` header must be a URI, so the source has to be encoded here
+		const destination = encodeUrl(this.source)
+		const temporaryUrl = await initChunkWorkspace(destination, 5, isPublicShare(), this.#customHeaders)
 
 		const promises: Promise<void>[] = []
 		const chunkSize = Math.floor(this.totalBytes / this.numberOfChunks)
@@ -149,7 +152,7 @@ export class UploadFile extends Upload implements IUpload {
 						...this.#customHeaders,
 						...getMtimeHeader(this.#file!),
 						'OC-Total-Length': this.totalBytes,
-						Destination: this.source,
+						Destination: destination,
 					},
 				})
 				this.status = UploadStatus.FINISHED

--- a/lib/upload/uploader/UploadFileTree.spec.ts
+++ b/lib/upload/uploader/UploadFileTree.spec.ts
@@ -191,6 +191,41 @@ describe('UploadFileTree', () => {
 		expect(tree.status).toBe(UploadStatus.FINISHED)
 	})
 
+	it('keeps sources unencoded but encodes them for requests', async () => {
+		// MKCOL fails with 405 so the directories already exist and conflicts need to be resolved
+		axiosRequestMock.mockRejectedValue({ response: { status: 405 } })
+		isAxiosErrorMock.mockReturnValue(true)
+
+		const conflictCallback = vi.fn(async (nodes: string[]) => Object.fromEntries(nodes.map((node) => [node, node])))
+
+		const directory = new Directory('/destination')
+		const folder = new Directory('/destination/sub folder')
+		await folder.addChild(new File(['nested'], 'näme #1.txt'))
+		await directory.addChildren([folder, new File(['root'], 'a b&c.txt')])
+
+		const tree = new UploadFileTree('/destination', directory, { callback: conflictCallback })
+		const children = tree.initialize()
+
+		// the sources are the plain (unencoded) names so they can be matched by the conflict callback
+		expect(children.map((child) => child.source)).toEqual([
+			'/destination/sub folder',
+			'/destination/a b&c.txt',
+			'/destination/sub folder/näme #1.txt',
+		])
+
+		await tree.start(createQueue())
+
+		// the conflict callback receives plain names, not encoded ones
+		expect(conflictCallback).toHaveBeenCalledWith(['sub folder', 'a b&c.txt'], '/destination')
+		expect(conflictCallback).toHaveBeenCalledWith(['näme #1.txt'], '/destination/sub folder')
+		// … while the requests use the encoded URLs
+		expect(axiosRequestMock.mock.calls.map(([{ url }]) => url)).toEqual([
+			'/destination',
+			'/destination/sub%20folder',
+		])
+		expect(tree.status).toBe(UploadStatus.FINISHED)
+	})
+
 	it('skips children that the conflict callback did not return', async () => {
 		// MKCOL fails with 405 so the directory already exists and conflicts need to be resolved
 		axiosRequestMock.mockRejectedValueOnce({ response: { status: 405 } })

--- a/lib/upload/uploader/UploadFileTree.spec.ts
+++ b/lib/upload/uploader/UploadFileTree.spec.ts
@@ -19,6 +19,7 @@ const isCancelMock = vi.hoisted(() => vi.fn())
 const uploadFileMocks = vi.hoisted(() => {
 	const instances: Array<{
 		source: string
+		signal: AbortSignal
 		start: ReturnType<typeof vi.fn>
 		cancel: ReturnType<typeof vi.fn>
 		status: number
@@ -27,11 +28,19 @@ const uploadFileMocks = vi.hoisted(() => {
 	class MockUploadFile {
 		public source: string
 		public status: number = UploadStatus.INITIALIZED
+
+		#abortController = new AbortController()
+
+		public get signal(): AbortSignal {
+			return this.#abortController.signal
+		}
+
 		public start = vi.fn(async () => {
 			this.status = UploadStatus.FINISHED
 		})
 
 		public cancel = vi.fn(() => {
+			this.#abortController.abort()
 			this.status = UploadStatus.CANCELLED
 		})
 
@@ -179,6 +188,82 @@ describe('UploadFileTree', () => {
 		expect(conflictCallback).toHaveBeenCalledOnce()
 		expect(conflictCallback).toHaveBeenCalledWith(['root.txt'], '/destination')
 		expect(tree.children[0].source).toBe('/destination/root-renamed.txt')
+		expect(tree.status).toBe(UploadStatus.FINISHED)
+	})
+
+	it('skips children that the conflict callback did not return', async () => {
+		// MKCOL fails with 405 so the directory already exists and conflicts need to be resolved
+		axiosRequestMock.mockRejectedValueOnce({ response: { status: 405 } })
+		isAxiosErrorMock.mockReturnValue(true)
+
+		// The callback keeps the existing version of 'root.txt' by not returning it
+		const conflictCallback = vi.fn(async (nodes: string[]) => Object.fromEntries(nodes
+			.filter((node) => node !== 'root.txt')
+			.map((node) => [node, node])))
+
+		const directory = new Directory('/destination')
+		await directory.addChildren([
+			new File(['root'], 'root.txt'),
+			new File(['other'], 'other.txt'),
+		])
+
+		const tree = new UploadFileTree('/destination', directory, { callback: conflictCallback })
+		tree.initialize()
+
+		const queue = createQueue()
+
+		await tree.start(queue)
+
+		expect(conflictCallback).toHaveBeenCalledOnce()
+		expect(conflictCallback).toHaveBeenCalledWith(['root.txt', 'other.txt'], '/destination')
+
+		// the skipped upload is not started but cancelled, the other one is uploaded
+		expect(uploadFileMocks.instances[0].source).toBe('/destination/root.txt')
+		expect(uploadFileMocks.instances[0].start).not.toHaveBeenCalled()
+		expect(uploadFileMocks.instances[0].status).toBe(UploadStatus.CANCELLED)
+		expect(uploadFileMocks.instances[1].source).toBe('/destination/other.txt')
+		expect(uploadFileMocks.instances[1].start).toHaveBeenCalledOnce()
+
+		expect(tree.status).toBe(UploadStatus.FINISHED)
+	})
+
+	it('skips whole folders - including their children - that the conflict callback did not return', async () => {
+		// MKCOL fails with 405 so the directory already exists and conflicts need to be resolved
+		axiosRequestMock.mockRejectedValueOnce({ response: { status: 405 } })
+		axiosRequestMock.mockResolvedValue({})
+		isAxiosErrorMock.mockReturnValue(true)
+
+		// The callback keeps the existing version of the 'folder' directory by not returning it
+		const conflictCallback = vi.fn(async (nodes: string[]) => Object.fromEntries(nodes
+			.filter((node) => node !== 'folder')
+			.map((node) => [node, node])))
+
+		const directory = await createDirectoryTree()
+		const tree = new UploadFileTree('/destination', directory, { callback: conflictCallback })
+		tree.initialize()
+
+		const queue = createQueue()
+
+		await tree.start(queue)
+
+		// the conflict callback is only called for the root, the skipped folder is never entered
+		expect(conflictCallback).toHaveBeenCalledOnce()
+		expect(conflictCallback).toHaveBeenCalledWith(['folder', 'root.txt'], '/destination')
+
+		const folderUpload = tree.children[0]
+		expect(folderUpload.source).toBe('/destination/folder')
+		expect(folderUpload.status).toBe(UploadStatus.CANCELLED)
+
+		// no MKCOL for the skipped folder, only the root directory was created
+		expect(axiosRequestMock).toHaveBeenCalledOnce()
+
+		// the nested file of the skipped folder is not uploaded
+		expect(uploadFileMocks.instances[0].source).toBe('/destination/folder/nested.txt')
+		expect(uploadFileMocks.instances[0].start).not.toHaveBeenCalled()
+		// but the not skipped root file is
+		expect(uploadFileMocks.instances[1].source).toBe('/destination/root.txt')
+		expect(uploadFileMocks.instances[1].start).toHaveBeenCalledOnce()
+
 		expect(tree.status).toBe(UploadStatus.FINISHED)
 	})
 

--- a/lib/upload/uploader/UploadFileTree.ts
+++ b/lib/upload/uploader/UploadFileTree.ts
@@ -12,7 +12,7 @@ import { UploadCancelledError } from '../errors/UploadCancelledError.ts'
 import { UploadFailedError } from '../errors/UploadFailedError.ts'
 import { Directory as FileTree } from '../utils/fileTree.ts'
 import { getMtimeHeader, isRequestAborted } from '../utils/requests.ts'
-import { concatUrl } from '../utils/url.ts'
+import { concatUrl, encodeUrl } from '../utils/url.ts'
 import { Upload, UploadStatus } from './Upload.ts'
 import { UploadFile } from './UploadFile.ts'
 
@@ -199,7 +199,7 @@ export class UploadFileTree extends Upload implements IUpload {
 	async #createDirectory(queue: PQueue): Promise<void> {
 		await queue.add(async () => {
 			try {
-				await axios.head(this.source, {
+				await axios.head(encodeUrl(this.source), {
 					signal: this.signal,
 					headers: {
 						...this.#customHeaders,
@@ -217,7 +217,7 @@ export class UploadFileTree extends Upload implements IUpload {
 			try {
 				await axios.request({
 					method: 'MKCOL',
-					url: this.source,
+					url: encodeUrl(this.source),
 					headers: {
 						...this.#customHeaders,
 						...getMtimeHeader(this.#directory),

--- a/lib/upload/uploader/UploadFileTree.ts
+++ b/lib/upload/uploader/UploadFileTree.ts
@@ -135,6 +135,7 @@ export class UploadFileTree extends Upload implements IUpload {
 
 		this.status = UploadStatus.UPLOADING
 		await this.#createDirectory(queue)
+
 		if (this.needConflictResolution && this.#conflictsCallback) {
 			const nodes = await this.#conflictsCallback(
 				this.#directory.children.map((node) => basename(node.name)),
@@ -145,16 +146,23 @@ export class UploadFileTree extends Upload implements IUpload {
 				return
 			}
 
-			for (const [originalName, newName] of Object.entries(nodes)) {
-				const upload = this.#children.find((child) => basename(child.source) === originalName)
-				if (upload) {
-					Object.defineProperty(upload, 'source', { value: concatUrl(this.source, newName) })
+			for (const childUpload of this.#children) {
+				const originalName = basename(childUpload.source)
+				const newName = nodes[originalName]
+				if (newName === undefined) {
+					childUpload.cancel()
+				} else if (newName !== originalName) {
+					Object.defineProperty(childUpload, 'source', { value: concatUrl(this.source, newName) })
 				}
 			}
 		}
 
 		const uploads: Promise<void>[] = []
 		for (const upload of this.#children) {
+			if (upload.signal.aborted) {
+				continue
+			}
+
 			// for folder tree uploads store the conflict resolution state to prevent useless requests
 			if (upload instanceof UploadFileTree) {
 				upload.needConflictResolution = this.needConflictResolution

--- a/lib/upload/uploader/Uploader.ts
+++ b/lib/upload/uploader/Uploader.ts
@@ -318,8 +318,6 @@ export class Uploader extends TypedEventTarget<UploaderEventsMap> {
 		const _callback = options?.callback
 		// The callback is adjusted to be called with the path relative to the upload target
 		// instead of the full absolute URL.
-		// We decode the path segments and strip a leading slash so the callback receives a
-		// clean relative path (e.g. '' for the target root, 'sub/deep' for a nested folder).
 		const callback = _callback && ((nodes: string[], path: string) => _callback(nodes, path.substring(target.length).replace(/^\//, '')))
 		const upload = new UploadFileTree(
 			target,

--- a/lib/upload/utils/url.spec.ts
+++ b/lib/upload/utils/url.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ */
+
+import { describe, expect, it } from 'vitest'
+import { concatUrl, encodeUrl } from './url.ts'
+
+describe('concatUrl', () => {
+	it('joins base and path', () => {
+		expect(concatUrl('https://example.com/dav', 'test.txt')).toBe('https://example.com/dav/test.txt')
+	})
+
+	it('normalizes slashes', () => {
+		expect(concatUrl('https://example.com/dav/', '/test.txt')).toBe('https://example.com/dav/test.txt')
+	})
+
+	it('does not encode the path', () => {
+		expect(concatUrl('https://example.com/dav', 'a b&c#1.txt')).toBe('https://example.com/dav/a b&c#1.txt')
+	})
+})
+
+describe('encodeUrl', () => {
+	it('encodes the path of an absolute URL', () => {
+		expect(encodeUrl('https://example.com/dav/a b&c#1.txt')).toBe('https://example.com/dav/a%20b%26c%231.txt')
+	})
+
+	it('encodes a plain path', () => {
+		expect(encodeUrl('/dav/sub folder/ä.txt')).toBe('/dav/sub%20folder/%C3%A4.txt')
+	})
+
+	it('keeps the origin untouched', () => {
+		expect(encodeUrl('http://localhost:8080/remote.php/dav/files/admin/+ 1.txt'))
+			.toBe('http://localhost:8080/remote.php/dav/files/admin/%2B%201.txt')
+	})
+
+	it('does not double encode path separators', () => {
+		expect(encodeUrl('https://example.com/a/b/c')).toBe('https://example.com/a/b/c')
+	})
+})

--- a/lib/upload/utils/url.ts
+++ b/lib/upload/utils/url.ts
@@ -3,6 +3,8 @@
  * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  */
 
+import { encodePath } from '@nextcloud/paths'
+
 /**
  * Concatenates a base URL (allowing protocol) and a path segment
  *
@@ -16,5 +18,17 @@ export function concatUrl(base: string, path: string): string {
 	if (path.startsWith('/')) {
 		path = path.slice(1)
 	}
-	return `${base}/${encodeURIComponent(path)}`
+	return `${base}/${path}`
+}
+
+/**
+ * URL encode the path of a decoded URL, leaving a potential origin untouched.
+ * This must be used whenever a source is used for a request (URL or `Destination` header).
+ *
+ * @param url - The decoded URL, either absolute ("https://example.com/dav/a b.txt") or a path ("/dav/a b.txt")
+ */
+export function encodeUrl(url: string): string {
+	// Only the path must be encoded, so keep a potential origin as-is
+	const origin = url.match(/^[a-z][a-z\d+\-.]*:\/\/[^/]*/i)?.[0] ?? ''
+	return origin + encodePath(url.slice(origin.length))
 }


### PR DESCRIPTION
If a file was skipped in the conflict resolution it must not be uploaded. Previously only renamed nodes were handled.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
